### PR TITLE
Add multi-source NIBE support (Modbus / nibe_heatpump) alongside MyUplink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ COMPLETED/
 Thumbs.db
 debug.log
 test_results.log
+
+# Playwright MCP browser artifacts (dev only)
+.playwright-mcp/
+
+# Simulation run output (regenerated; not committed)
+scripts/simulation/output/

--- a/README.md
+++ b/README.md
@@ -100,10 +100,17 @@ Production-ready safety mechanisms:
 ## Requirements
 
 - **Home Assistant** 2025.10+
-- **Compatible heat pump** with [MyUplink integration](https://www.home-assistant.io/integrations/myuplink/)
-  - NIBE: F2040, F750, F730, S1155, S-series (currently supported)
-  - Additional brands: Planned for future releases
-- **MyUplink integration** configured
+- **Compatible NIBE heat pump** connected through ONE of these data sources:
+  - [MyUplink integration](https://www.home-assistant.io/integrations/myuplink/) (cloud;
+    writes may require a valid myUplink subscription)
+  - [nibe_heatpump integration](https://www.home-assistant.io/integrations/nibe_heatpump/)
+    (local: NibeGW/MODBUS40 for F-series, built-in Modbus TCP for S-series; no
+    subscription needed — recommended for local Modbus users)
+  - Generic [Modbus](https://www.home-assistant.io/integrations/modbus/) YAML sensors plus
+    [template numbers](https://www.home-assistant.io/integrations/template/) for writable
+    registers (see [Local Modbus setups](#local-modbus-setups))
+  - Models: F750, F730, F1155, F2040, S1155 (profiles); similar NIBE models work with the
+    nearest profile. Additional brands: planned for future releases
 - **Price integration** with 15-min data (GE-Spot, Nordpool, Tibber, etc.)
 - **Weather integration** (Met.no or equivalent)
 
@@ -139,6 +146,53 @@ System auto-detects:
 - UFH type (from thermal lag)
 - Heat pump model (from entity patterns)
 - Pump configuration (validates against system type)
+
+Sensors are found automatically by entity-name patterns (MyUplink, nibe_heatpump,
+and common Modbus namings). If discovery misses a sensor — typical for generic
+Modbus YAML setups — set it manually via the **override fields** in the Sensors
+step, or later via **Reconfigure** on the integration.
+
+### Local Modbus setups
+
+The recommended local path is the official
+[nibe_heatpump](https://www.home-assistant.io/integrations/nibe_heatpump/) integration:
+it exposes read-only registers as sensors (e.g. `sensor.bt1_outdoor_temperature_40004`)
+and writable registers as **numbers** (e.g. `number.heat_offset_s1_47011`,
+`number.degree_minutes_16_bit_43005`). All its entities are **disabled by default** —
+enable at least BT1, BT50, BT2/BT25, BT3, BT7, BT6, degree minutes, compressor state,
+and Heat Offset S1 in Settings → Devices & Services → NIBE → entities.
+
+With the generic `modbus` integration, define sensors for the registers above
+(F-series values are raw ×10 — use `scale: 0.1`) and wrap the offset register in a
+template number so EffektGuard can write it:
+
+```yaml
+template:
+  - number:
+      - name: "Heat Offset S1 47011"
+        unique_id: nibe_heat_offset_s1_47011
+        state: "{{ states('sensor.heat_offset_s1_47011') | float(0) }}"
+        availability: "{{ has_value('sensor.heat_offset_s1_47011') }}"
+        min: -10
+        max: 10
+        step: 1
+        set_value:
+          - action: modbus.write_register
+            data:
+              hub: nibe
+              slave: 1
+              address: 47011
+              value: "{{ (value | int) % 65536 }}"
+```
+
+`min`/`max`/`step` are required as shown — a template number defaults to
+0–100 and would reject negative offsets. `unique_id` registers the entity so
+it is UI-editable and preferred by discovery; the `availability` guard stops
+the number from erroring while the Modbus hub is down. Writes take effect
+immediately; the displayed value catches up on the sensor's next poll
+(`scan_interval`, 15 s default).
+
+Select that number as the offset entity in the first setup step.
 
 ## Architecture
 

--- a/custom_components/effektguard/__init__.py
+++ b/custom_components/effektguard/__init__.py
@@ -103,8 +103,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Clean up on failure
         hass.data[DOMAIN].pop(entry.entry_id, None)
         raise ConfigEntryNotReady(
-            f"Failed to connect to NIBE heat pump. "
-            f"Ensure MyUplink integration is loaded and entities are available."
+            "Failed to connect to NIBE heat pump. Ensure your NIBE integration "
+            "(MyUplink, nibe_heatpump, or Modbus) is loaded and its entities "
+            "are available."
         ) from err
 
     # Set up power sensor availability listener AFTER first refresh
@@ -157,6 +158,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 def _async_unregister_services(hass: HomeAssistant) -> None:
     """Unregister integration services when last config entry is removed."""
     from .const import (
+        SERVICE_BOOST_DHW,
         SERVICE_BOOST_HEATING,
         SERVICE_CALCULATE_OPTIMAL_SCHEDULE,
         SERVICE_FORCE_OFFSET,
@@ -167,6 +169,7 @@ def _async_unregister_services(hass: HomeAssistant) -> None:
         SERVICE_FORCE_OFFSET,
         SERVICE_RESET_PEAK_TRACKING,
         SERVICE_BOOST_HEATING,
+        SERVICE_BOOST_DHW,
         SERVICE_CALCULATE_OPTIMAL_SCHEDULE,
     ]
 

--- a/custom_components/effektguard/adapters/nibe_adapter.py
+++ b/custom_components/effektguard/adapters/nibe_adapter.py
@@ -1,13 +1,20 @@
-"""NIBE Myuplink adapter for reading heat pump state.
+"""NIBE adapter for reading heat pump state from Home Assistant entities.
 
-This adapter reads NIBE heat pump data from existing Home Assistant entities
-created by the NIBE Myuplink integration. It does not directly communicate
-with the MyUplink API.
+This adapter reads NIBE heat pump data from existing Home Assistant entities.
+It never calls external APIs. Supported sources (issue #18):
+- myuplink (cloud): writable parameters are NUMBER entities
+- nibe_heatpump (local NibeGW/Modbus): entity ids embed register numbers,
+  writable coils are NUMBER entities
+- generic modbus YAML sensors + template numbers wrapping modbus.write_register
+
+Entities are found via manual config-flow overrides first (authoritative),
+then name-pattern discovery over the state machine and entity registry
+(NIBE_DISCOVERY_PATTERNS in const.py).
 
 Data read includes:
 - Indoor temperature (BT50 or room sensor)
 - Outdoor temperature (BT1)
-- Supply temperature (BT25 on F2040, BT63 on F750)
+- Supply temperature (BT2/BT25, BT63 on MyUplink F750)
 - Return temperature (BT3)
 - Degree minutes (GM/DM)
 - Current heating curve offset
@@ -21,6 +28,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
@@ -33,11 +41,28 @@ from ..const import (
     DEFAULT_BASE_POWER,
     DEFAULT_INDOOR_TEMP,
     DEFAULT_INDOOR_TEMP_METHOD,
+    DOMAIN,
     MAX_OFFSET,
     MIN_OFFSET,
+    NIBE_COMPRESSOR_ACTIVE_HZ_THRESHOLD,
     NIBE_DEFAULT_SUPPLY_TEMP,
+    NIBE_DISCOVERY_CORE_KEYS,
+    NIBE_DISCOVERY_EXCLUDE,
+    NIBE_DISCOVERY_MAX_ATTEMPTS,
+    NIBE_DISCOVERY_PATTERNS,
+    NIBE_DISCOVERY_RANK_LIVE,
+    NIBE_DISCOVERY_RANK_LIVE_UNREGISTERED,
+    NIBE_DISCOVERY_RANK_MANUAL,
+    NIBE_DISCOVERY_RANK_REGISTRY_ONLY,
+    NIBE_DISCOVERY_SLOW_RETRY_CYCLES,
     NIBE_FRACTIONAL_ACCUMULATOR_THRESHOLD,
+    NIBE_MANUAL_OVERRIDE_KEYS,
+    NIBE_OFFSET_RESYNC_MINUTES,
     NIBE_POWER_FACTOR,
+    NIBE_STATUS_ACTIVE_STATES,
+    NIBE_SWITCH_DISCOVERY_PATTERNS,
+    NIBE_TEMPERATURE_KEYS,
+    NIBE_UNKNOWN_VALUE_MARKERS,
     NIBE_VOLTAGE_PER_PHASE,
     SERVICE_RATE_LIMIT_MINUTES,
     TEMP_FACTOR_MAX,
@@ -108,14 +133,34 @@ class NibeAdapter:
             config: Configuration dictionary with entity IDs
         """
         self.hass = hass
-        self._nibe_base_entity = config.get(CONF_NIBE_ENTITY)
         self._degree_minutes_entity = config.get(CONF_DEGREE_MINUTES_ENTITY)  # Optional
         self._power_sensor_entity = config.get(CONF_POWER_SENSOR_ENTITY)  # Optional
         self._additional_indoor_sensors = config.get(CONF_ADDITIONAL_INDOOR_SENSORS, [])  # Optional
         self._indoor_temp_method = config.get(CONF_INDOOR_TEMP_METHOD, DEFAULT_INDOOR_TEMP_METHOD)
+        # Manual entity overrides beat pattern discovery (issue #18: Modbus/renamed
+        # entities cannot rely on name patterns). The offset entity the user picked
+        # in the first config step is authoritative for the write path.
+        self._manual_overrides: dict[str, str] = {}
+        if config.get(CONF_NIBE_ENTITY):
+            self._manual_overrides["offset"] = config[CONF_NIBE_ENTITY]
+        if self._degree_minutes_entity:
+            self._manual_overrides["degree_minutes"] = self._degree_minutes_entity
+        for cache_key, conf_key in NIBE_MANUAL_OVERRIDE_KEYS.items():
+            if config.get(conf_key):
+                self._manual_overrides[cache_key] = config[conf_key]
         self._last_write: datetime | None = None
         self._last_ventilation_write: datetime | None = None
-        self._entity_cache: dict[str, str] = {}
+        # Rank of each cached discovery result, persisted across discovery
+        # passes so a live entity found later still displaces a registry-only
+        # entry cached during startup
+        self._entity_ranks: dict[str, int] = {}
+        # Seed overrides immediately: consumers like the coordinator's offset
+        # sync read entity_cache before the first discovery pass runs
+        self._entity_cache: dict[str, str] = dict(self._manual_overrides)
+        for key in self._manual_overrides:
+            self._entity_ranks[key] = NIBE_DISCOVERY_RANK_MANUAL
+        self._discovery_attempts: int = 0
+        self._cycles_since_discovery: int = 0
         # Fractional accumulator for precise offset tracking
         # NIBE only accepts integers, so we accumulate fractional parts
         # and apply them when they sum to ±1°C
@@ -140,17 +185,33 @@ class NibeAdapter:
     async def get_current_state(self) -> NibeState:
         """Read current NIBE heat pump state from entities.
 
+        Missing entities are read as safe defaults - see the per-field
+        defaults below and the discovery warnings in _discover_nibe_entities.
+
         Returns:
             NibeState with current readings
-
-        Raises:
-            ValueError: If required entities are unavailable
         """
-        # This will be implemented in Phase 1
-        # For now, discover and read NIBE entities
-
-        # Discover NIBE entities if not cached
-        if not self._entity_cache:
+        # Discover NIBE entities if not cached. Re-discover while core sensors
+        # are missing OR only backed by registry entries without a live state
+        # yet: source integrations (modbus, nibe_heatpump, myuplink) may create
+        # their entities AFTER our first pass during HA startup, and a stale
+        # registry id must not permanently block the live entity (issue #18).
+        # Capped: a sensor still absent after NIBE_DISCOVERY_MAX_ATTEMPTS
+        # cycles does not exist in this setup (e.g. no BT50 room sensor).
+        core_unresolved = any(
+            key not in self._entity_cache
+            or self._entity_ranks.get(key, NIBE_DISCOVERY_RANK_LIVE)
+            >= NIBE_DISCOVERY_RANK_REGISTRY_ONLY
+            for key in NIBE_DISCOVERY_CORE_KEYS
+        )
+        self._cycles_since_discovery += 1
+        if not self._entity_cache or (
+            core_unresolved
+            and (
+                self._discovery_attempts < NIBE_DISCOVERY_MAX_ATTEMPTS
+                or self._cycles_since_discovery >= NIBE_DISCOVERY_SLOW_RETRY_CYCLES
+            )
+        ):
             await self._discover_nibe_entities()
 
         # Read temperature sensors
@@ -250,6 +311,13 @@ class NibeAdapter:
             self._entity_cache.get("compressor_hz"), default=None
         )
 
+        # Derive heating activity from compressor frequency when the status
+        # entity is missing or unparseable (raw Modbus 43427 is a numeric enum
+        # that _read_entity_bool cannot interpret). A DHW-only run also spins
+        # the compressor, so hot-water production must not count as heating.
+        if not is_heating and not is_hot_water and compressor_hz is not None:
+            is_heating = compressor_hz > NIBE_COMPRESSOR_ACTIVE_HZ_THRESHOLD
+
         # Log current sensors if available
         if phase1_current is not None:
             _LOGGER.debug(
@@ -280,15 +348,16 @@ class NibeAdapter:
             phase1_current=phase1_current,
             phase2_current=phase2_current,
             phase3_current=phase3_current,
-            compressor_hz=int(compressor_hz) if compressor_hz else None,
+            compressor_hz=int(compressor_hz) if compressor_hz is not None else None,
             power_kw=power_kw,
         )
 
     async def set_curve_offset(self, offset: float) -> bool:
         """Set heating curve offset via NIBE entity with fractional accumulation.
 
-        NIBE MyUplink entities have step=1 (integer only), but the optimization
-        engine calculates precise fractional offsets (e.g., 0.35°C, -1.24°C).
+        The NIBE offset register (47011 on F-series) is integer-only, but the
+        optimization engine calculates precise fractional offsets (e.g., 0.35°C,
+        -1.24°C).
 
         Solution: Accumulate fractional parts and apply when they sum to ±1°C.
         This preserves the precision of gentle optimization while respecting
@@ -307,7 +376,10 @@ class NibeAdapter:
             True if offset was written to NIBE, False if deferred/accumulated
 
         Note:
-            Requires NIBE Myuplink Premium subscription for write access.
+            The target must be a writable number entity: a MyUplink offset
+            number (cloud writes may require a valid myUplink subscription), a
+            nibe_heatpump number (e.g. number.heat_offset_s1_47011), or a
+            template number wrapping modbus.write_register.
         """
         # Rate limiting - minimum time between writes
         now = dt_util.utcnow()
@@ -333,21 +405,34 @@ class NibeAdapter:
             )
             return False
 
-        # Read current NIBE offset on first call (sync with actual state)
-        if self._last_nibe_offset is None:
-            try:
-                self._last_nibe_offset = int(float(state.state))
-                # Initialize accumulator based on difference between calculated and actual
-                self._fractional_accumulator = offset - self._last_nibe_offset
-                _LOGGER.info(
-                    "✓ Synced with NIBE: current offset %d°C (calculated: %.2f°C, accumulator: %.2f°C)",
-                    self._last_nibe_offset,
-                    offset,
-                    self._fractional_accumulator,
-                )
-            except (ValueError, TypeError):
-                self._last_nibe_offset = 0
-                self._fractional_accumulator = offset
+        # Sync with the entity's actual value on first call, and re-sync when
+        # the entity disagrees with our bookkeeping and we have not written
+        # recently: the offset can change externally (pump display, another
+        # automation) or a fire-and-forget write may have failed silently.
+        entity_offset: int | None = None
+        try:
+            entity_offset = int(float(state.state))
+        except (ValueError, TypeError):
+            pass
+
+        resync_window_passed = self._last_write is None or now - self._last_write >= timedelta(
+            minutes=NIBE_OFFSET_RESYNC_MINUTES
+        )
+        if entity_offset is not None and (
+            self._last_nibe_offset is None
+            or (entity_offset != self._last_nibe_offset and resync_window_passed)
+        ):
+            self._last_nibe_offset = entity_offset
+            self._fractional_accumulator = offset - self._last_nibe_offset
+            _LOGGER.info(
+                "✓ Synced with NIBE: current offset %d°C (calculated: %.2f°C, accumulator: %.2f°C)",
+                self._last_nibe_offset,
+                offset,
+                self._fractional_accumulator,
+            )
+        elif self._last_nibe_offset is None:
+            self._last_nibe_offset = 0
+            self._fractional_accumulator = offset
 
         # Fractional accumulation logic
         # The accumulator tracks the total difference between what we've calculated
@@ -399,10 +484,37 @@ class NibeAdapter:
             )
             return False
 
+        # Respect the target entity's own limits when it exposes them
+        # (a template number left at default min 0/max 100 would otherwise
+        # reject every negative offset in a background task we never see).
+        # Defensive float() - a malformed entity must never crash the write.
+        try:
+            entity_min = float(state.attributes["min"])
+            entity_max = float(state.attributes["max"])
+        except (KeyError, TypeError, ValueError):
+            entity_min = entity_max = None
+        if entity_min is not None and entity_max is not None:
+            clamped = int(max(entity_min, min(float(offset_to_apply), entity_max)))
+            if clamped != offset_to_apply:
+                _LOGGER.warning(
+                    "Offset %d°C outside %s range [%s, %s], clamping to %d°C - "
+                    "check the number entity's min/max configuration",
+                    offset_to_apply,
+                    offset_entity,
+                    entity_min,
+                    entity_max,
+                    clamped,
+                )
+                offset_to_apply = clamped
+                if offset_to_apply == self._last_nibe_offset:
+                    return False
+
         # Store old value for logging before updating
         old_offset = self._last_nibe_offset
 
-        # Write to NIBE
+        # Write to NIBE. blocking=True so handler failures (out-of-range,
+        # unavailable target, cloud errors) surface here instead of being
+        # swallowed in a background task while we record a phantom success.
         try:
             await self.hass.services.async_call(
                 "number",
@@ -411,7 +523,7 @@ class NibeAdapter:
                     "entity_id": offset_entity,
                     "value": offset_to_apply,
                 },
-                blocking=False,
+                blocking=True,
             )
             self._last_write = now
             self._last_nibe_offset = offset_to_apply
@@ -425,7 +537,7 @@ class NibeAdapter:
             )
             return True
 
-        except (AttributeError, OSError, ValueError, TypeError) as err:
+        except (HomeAssistantError, AttributeError, OSError, ValueError, TypeError) as err:
             _LOGGER.error("Failed to set NIBE offset: %s", err)
             return False
 
@@ -495,7 +607,7 @@ class NibeAdapter:
                 "switch",
                 service,
                 {"entity_id": ventilation_entity},
-                blocking=False,
+                blocking=True,
             )
 
             self._last_ventilation_write = now
@@ -503,7 +615,7 @@ class NibeAdapter:
             _LOGGER.info("✓ Ventilation set to %s via %s", status, ventilation_entity)
             return True
 
-        except (AttributeError, OSError, ValueError, TypeError) as err:
+        except (HomeAssistantError, AttributeError, OSError, ValueError, TypeError) as err:
             _LOGGER.error("Failed to set enhanced ventilation: %s", err)
             return False
 
@@ -525,172 +637,106 @@ class NibeAdapter:
         return state.state == "on"
 
     async def _discover_nibe_entities(self) -> None:
-        """Discover NIBE entities from entity registry.
+        """Discover NIBE source entities.
 
-        Populates _entity_cache with entity IDs for:
-        - outdoor_temp (BT1)
-        - indoor_temp (BT50 or room sensor)
-        - supply_temp (BT25 on F2040, BT63 on F750)
-        - return_temp (BT3)
-        - degree_minutes (GM/DM)
-        - offset (S1 offset)
-        - compressor_status
-        - hot_water_status
-        - dhw_top_temp (BT7 - hot water top)
-        - dhw_charging_temp (BT6 - hot water charging/bottom)
+        Population order (first wins):
+        1. Manual config-flow overrides (authoritative - issue #18 Modbus setups)
+        2. Entities in the state machine matching NIBE_DISCOVERY_PATTERNS.
+           Scanning states (not only the registry) is REQUIRED: generic Modbus
+           YAML entities without unique_id never enter the entity registry.
+        3. Enabled registry entries without a state yet (integration still
+           starting) - lowest priority, never beats a live entity.
+
+        Ranks persist across passes (self._entity_ranks) so a live entity
+        appearing after startup still displaces a registry-only entry.
+
+        Matching rules:
+        - Keys are tried in NIBE_DISCOVERY_PATTERNS dict order; each entity can
+          satisfy at most one key (specific temperature keys are ordered before
+          broad status keys to prevent e.g. hot_water_status grabbing BT7).
+        - Temperature keys require device_class temperature or a °C/°F unit.
+        - The offset key requires a number entity (write path uses
+          number.set_value; a read-only Modbus offset sensor must never win).
+        - EffektGuard's own entities are excluded by registry platform.
         """
+        self._discovery_attempts += 1
+        self._cycles_since_discovery = 0
+        previous_cache = dict(self._entity_cache)
+
+        for key, entity_id in self._manual_overrides.items():
+            self._entity_cache[key] = entity_id
+            self._entity_ranks[key] = NIBE_DISCOVERY_RANK_MANUAL
+
+        ranks = self._entity_ranks
+        claimed: set[str] = set(self._entity_cache.values())
+
         registry = er.async_get(self.hass)
+        live_ids = set()
 
-        # Search for NIBE entities
-        # Patterns based on NIBE Myuplink integration entity naming
-        # Use specific entity names from parameter IDs when possible
-        # CRITICAL: Use word boundaries (_btX, btX_) to prevent substring matches
-        # e.g., "bt6" would match "bt63", "bt1" would match "bt10", etc.
-        # This ensures we match the exact sensor, not similar named sensors
-        patterns = {
-            "outdoor_temp": ["_bt1", "bt1_", "outdoor_temp", "40004"],  # BT1 / param 40004
-            "indoor_temp": [
-                "_bt50",
-                "bt50_",
-                "room_temperature",
-                "40033",
-            ],  # BT50 / param 40033 "Temperature"
-            "supply_temp": [
-                "_bt25",
-                "bt25_",
-                "_bt63",
-                "bt63_",
-                "supply_temp",
-                "heating_medium_supply",
-                "40008",
-            ],  # BT25 (F2040) or BT63 (F750) / param 40008
-            "return_temp": ["_bt3", "bt3_", "return_temp", "40012"],  # BT3 / param 40012
-            "degree_minutes": ["degree_minutes", "40941"],  # param 40941
-            "offset": ["offset", "47011"],  # param 47011
-            "compressor_status": ["compressor", "43427"],  # param 43427
-            "hot_water_status": ["hot_water", "dhw"],
-            "dhw_top_temp": [
-                "_bt7",
-                "bt7_",
-                "hw_top",
-                "40013",
-            ],  # BT7 / param 40013 - hot water top
-            "dhw_charging_temp": [
-                "_bt6",
-                "bt6_",
-                "hw_bottom",
-                "hw_charging",
-                "40014",
-            ],  # BT6 / param 40014
-            "dhw_amount": [
-                "hot_water_amount",
-                "hw_amount",
-            ],  # Hot water amount in minutes
-            "phase1_current": [
-                "current_be1",
-                "_be1",
-                "phase_1_current",
-                "43086",
-            ],  # BE1 / param 43086
-            "phase2_current": [
-                "current_be2",
-                "_be2",
-                "phase_2_current",
-                "43122",
-            ],  # BE2 / param 43122
-            "phase3_current": [
-                "current_be3",
-                "_be3",
-                "phase_3_current",
-                "electrical_addition",
-                "43081",
-            ],  # BE3 / param 43081
-            "compressor_hz": [
-                "compressor_frequency",
-                "43136",
-            ],  # Compressor frequency param 43136
-        }
-
-        # Find sensor/number entities
-        for entity in registry.entities.values():
-            if not entity.entity_id.startswith("sensor.") and not entity.entity_id.startswith(
-                "number."
-            ):
+        for state in self.hass.states.async_all(("sensor", "number")):
+            live_ids.add(state.entity_id)
+            # Never discover our own entities (e.g. sensor.effektguard_dhw_status
+            # would match the hot_water_status patterns)
+            registry_entry = registry.async_get(state.entity_id)
+            if registry_entry and registry_entry.platform == DOMAIN:
                 continue
-
-            entity_id_lower = entity.entity_id.lower()
-
-            # Skip known non-temperature configuration parameters
-            # 47394 = "control room sensor syst" (configuration, not temperature)
-            if "47394" in entity_id_lower or "control_room_sensor" in entity_id_lower:
-                continue
-
-            # Match against patterns
-            for key, patterns_list in patterns.items():
-                if key not in self._entity_cache:
-                    for pattern in patterns_list:
-                        if pattern in entity_id_lower:
-                            # Additional validation for temperature sensors
-                            if key in [
-                                "outdoor_temp",
-                                "indoor_temp",
-                                "supply_temp",
-                                "return_temp",
-                                "dhw_top_temp",
-                                "dhw_charging_temp",
-                            ]:
-                                # Check if it's actually a temperature sensor
-                                state = self.hass.states.get(entity.entity_id)
-                                if state:
-                                    device_class = state.attributes.get("device_class")
-                                    unit = state.attributes.get("unit_of_measurement")
-
-                                    # Accept if device_class is temperature OR unit is °C/°F
-                                    # This handles cases where device_class is not set but unit is
-                                    is_temp_sensor = device_class == "temperature" or unit in [
-                                        "°C",
-                                        "°F",
-                                        "C",
-                                        "F",
-                                    ]
-
-                                    if not is_temp_sensor:
-                                        _LOGGER.debug(
-                                            "Skipping %s (not a temperature sensor, device_class=%s, unit=%s): %s",
-                                            key,
-                                            device_class,
-                                            unit,
-                                            entity.entity_id,
-                                        )
-                                        continue
-
-                            self._entity_cache[key] = entity.entity_id
-                            _LOGGER.debug("Found NIBE entity %s: %s", key, entity.entity_id)
-                            break
-
-        # Discover switch entities (separate loop for increased_ventilation)
-        switch_patterns = {
-            "increased_ventilation": [
-                "increased_ventilation",
-            ],  # NIBE F750/F730 enhanced ventilation switch
-        }
+            # Integration-backed entities outrank template/YAML lookalikes
+            # without a registry entry (generic Modbus setups still win when
+            # nothing registered matches)
+            self._consider_candidate(
+                state.entity_id,
+                state.attributes.get("device_class"),
+                state.attributes.get("unit_of_measurement"),
+                (
+                    NIBE_DISCOVERY_RANK_LIVE
+                    if registry_entry
+                    else NIBE_DISCOVERY_RANK_LIVE_UNREGISTERED
+                ),
+                ranks,
+                claimed,
+            )
 
         for entity in registry.entities.values():
-            if not entity.entity_id.startswith("switch."):
+            if entity.entity_id in live_ids or entity.disabled_by is not None:
                 continue
+            if entity.domain not in ("sensor", "number") or entity.platform == DOMAIN:
+                continue
+            self._consider_candidate(
+                entity.entity_id,
+                entity.device_class or entity.original_device_class,
+                entity.unit_of_measurement,
+                NIBE_DISCOVERY_RANK_REGISTRY_ONLY,
+                ranks,
+                claimed,
+            )
 
-            entity_id_lower = entity.entity_id.lower()
+        # Discover switch entities (separate domain scan for increased_ventilation).
+        # Registry entries are included so a switch platform that loads after
+        # our last discovery pass is still found (its entity id is registered
+        # before its state exists).
+        switch_ids = [state.entity_id for state in self.hass.states.async_all("switch")]
+        switch_ids += [
+            entity.entity_id
+            for entity in registry.entities.values()
+            if entity.domain == "switch"
+            and entity.disabled_by is None
+            and entity.platform != DOMAIN
+            and entity.entity_id not in switch_ids
+        ]
+        for entity_id in switch_ids:
+            entity_id_lower = entity_id.lower()
+            for key, patterns_list in NIBE_SWITCH_DISCOVERY_PATTERNS.items():
+                if key not in self._entity_cache and any(
+                    pattern in entity_id_lower for pattern in patterns_list
+                ):
+                    self._entity_cache[key] = entity_id
+                    _LOGGER.debug("Found NIBE switch %s: %s", key, entity_id)
 
-            # Match against switch patterns
-            for key, patterns_list in switch_patterns.items():
-                if key not in self._entity_cache:
-                    for pattern in patterns_list:
-                        if pattern in entity_id_lower:
-                            self._entity_cache[key] = entity.entity_id
-                            _LOGGER.debug("Found NIBE switch %s: %s", key, entity.entity_id)
-                            break
+        # Log results only when they changed (rediscovery runs during startup
+        # while core sensors are missing - identical repeats are just noise)
+        if self._entity_cache == previous_cache:
+            return
 
-        # Log all discovered entities for debugging
         _LOGGER.info("NIBE Entity Discovery: Found %d entities", len(self._entity_cache))
         for key, entity_id in self._entity_cache.items():
             state = self.hass.states.get(entity_id)
@@ -709,6 +755,75 @@ class NibeAdapter:
             _LOGGER.warning("No outdoor temperature sensor (BT1) found!")
         if "degree_minutes" not in self._entity_cache:
             _LOGGER.warning("No degree minutes sensor found, will estimate from thermal model")
+
+    def _consider_candidate(
+        self,
+        entity_id: str,
+        device_class: str | None,
+        unit: str | None,
+        rank: int,
+        ranks: dict[str, int],
+        claimed: set[str],
+    ) -> None:
+        """Match one entity against the pattern table and cache it if it wins.
+
+        Args:
+            entity_id: Candidate entity id
+            device_class: Its device class (state attribute or registry)
+            unit: Its unit of measurement (state attribute or registry)
+            rank: Candidate quality (lower wins; live state beats registry-only)
+            ranks: Current rank per cached key (mutated)
+            claimed: Entity ids already assigned to a key (mutated)
+        """
+        if entity_id in claimed:
+            # Already bound to a key - refresh its rank so a registry-only
+            # binding whose state has appeared becomes a live binding
+            # (otherwise it stays displaceable and core_unresolved never
+            # settles)
+            for key, cached_id in self._entity_cache.items():
+                if cached_id == entity_id and rank < ranks.get(key, rank):
+                    ranks[key] = rank
+            return
+
+        entity_id_lower = entity_id.lower()
+        if any(excluded in entity_id_lower for excluded in NIBE_DISCOVERY_EXCLUDE):
+            return
+
+        for key, patterns_list in NIBE_DISCOVERY_PATTERNS.items():
+            if not any(pattern in entity_id_lower for pattern in patterns_list):
+                continue
+
+            if key in NIBE_TEMPERATURE_KEYS:
+                # Accept if device_class is temperature OR unit is °C/°F
+                # (handles Modbus sensors where only the unit is configured)
+                if device_class != "temperature" and unit not in ["°C", "°F", "C", "F"]:
+                    _LOGGER.debug(
+                        "Skipping %s (not a temperature sensor, device_class=%s, unit=%s): %s",
+                        key,
+                        device_class,
+                        unit,
+                        entity_id,
+                    )
+                    continue
+
+            if key == "offset" and not entity_id.startswith("number."):
+                # Write path calls number.set_value - a sensor can never work
+                _LOGGER.debug("Skipping offset candidate %s (not a number entity)", entity_id)
+                continue
+
+            # The entity belongs to this key; cache it only if it outranks the
+            # current holder, then stop either way (one key per entity).
+            if key in self._entity_cache and ranks.get(key, NIBE_DISCOVERY_RANK_LIVE) <= rank:
+                return
+
+            previous = self._entity_cache.get(key)
+            if previous:
+                claimed.discard(previous)
+            self._entity_cache[key] = entity_id
+            ranks[key] = rank
+            claimed.add(entity_id)
+            _LOGGER.debug("Found NIBE entity %s: %s", key, entity_id)
+            return
 
     async def _read_entity_float(
         self,
@@ -732,10 +847,17 @@ class NibeAdapter:
             return default
 
         try:
-            return float(state.state)
+            value = float(state.state)
         except (ValueError, TypeError):
             _LOGGER.warning("Cannot parse float from %s: %s", entity_id, state.state)
             return default
+
+        if value in NIBE_UNKNOWN_VALUE_MARKERS:
+            # s16 unknown-value marker (MyUplink / disconnected Modbus sensor)
+            _LOGGER.debug("Ignoring unknown-value marker %s from %s", value, entity_id)
+            return default
+
+        return value
 
     async def _read_entity_bool(
         self,
@@ -758,7 +880,9 @@ class NibeAdapter:
         if not state or state.state in ["unknown", "unavailable"]:
             return default
 
-        return state.state in ["on", "true", "True", "ON", "1"]
+        # Lowercase comparison covers on/off switches plus mapped coil states
+        # from nibe_heatpump/myuplink ("Running", "Starting")
+        return state.state.lower() in NIBE_STATUS_ACTIVE_STATES
 
     def _estimate_degree_minutes(
         self, indoor_temp: float, supply_temp: float, outdoor_temp: float
@@ -808,8 +932,7 @@ class NibeAdapter:
 
         Tries in order:
         1. Configured power sensor (most accurate)
-        2. Auto-discovered heat pump power sensor
-        3. Estimation from supply temperature (least accurate)
+        2. Estimation from supply temperature (least accurate)
 
         Returns:
             Power consumption in kW, or None if unavailable
@@ -829,19 +952,6 @@ class NibeAdapter:
                     self._power_sensor_entity,
                     power,
                 )
-                return power
-
-        # Try auto-discovered power sensor
-        power_entity = self._entity_cache.get("power")
-        if power_entity:
-            power = await self._read_entity_float(power_entity, default=None)
-            if power is not None:
-                state = self.hass.states.get(power_entity)
-                if state:
-                    unit = state.attributes.get("unit_of_measurement", "").lower()
-                    if unit == "w":
-                        power = power / 1000.0
-                _LOGGER.debug("Using auto-discovered power sensor: %.2f kW", power)
                 return power
 
         # Fall back to estimation from supply temperature

--- a/custom_components/effektguard/adapters/nibe_adapter.py
+++ b/custom_components/effektguard/adapters/nibe_adapter.py
@@ -59,6 +59,8 @@ from ..const import (
     NIBE_MANUAL_OVERRIDE_KEYS,
     NIBE_OFFSET_RESYNC_MINUTES,
     NIBE_POWER_FACTOR,
+    NIBE_PRIO_HEATING_STATES,
+    NIBE_PRIO_HOT_WATER_STATES,
     NIBE_STATUS_ACTIVE_STATES,
     NIBE_SWITCH_DISCOVERY_PATTERNS,
     NIBE_TEMPERATURE_KEYS,
@@ -276,6 +278,16 @@ class NibeAdapter:
             self._entity_cache.get("hot_water_status"), default=False
         )
 
+        # Priority (register 43086) identifies what the compressor is serving.
+        # It overrides the broad status patterns: a DHW-priority run must not
+        # count as space heating (nibe_heatpump reports compressor "Running"
+        # during DHW production while no hot_water_status entity exists).
+        prio = self._read_prio_state()
+        if prio == "hot_water":
+            is_hot_water = True
+        elif prio == "heating":
+            is_hot_water = False
+
         # Read DHW temperatures (optional - BT7 top, BT6 charging/bottom)
         dhw_top_temp = await self._read_entity_float(
             self._entity_cache.get("dhw_top_temp"), default=None
@@ -317,6 +329,11 @@ class NibeAdapter:
         # the compressor, so hot-water production must not count as heating.
         if not is_heating and not is_hot_water and compressor_hz is not None:
             is_heating = compressor_hz > NIBE_COMPRESSOR_ACTIVE_HZ_THRESHOLD
+
+        # Final priority override: whatever the status entities claimed, a
+        # hot-water-priority compressor run is not space heating
+        if prio == "hot_water":
+            is_heating = False
 
         # Log current sensors if available
         if phase1_current is not None:
@@ -883,6 +900,32 @@ class NibeAdapter:
         # Lowercase comparison covers on/off switches plus mapped coil states
         # from nibe_heatpump/myuplink ("Running", "Starting")
         return state.state.lower() in NIBE_STATUS_ACTIVE_STATES
+
+    def _read_prio_state(self) -> str | None:
+        """Read the pump priority (register 43086) and classify it.
+
+        Covers nibe_heatpump mapped strings ("Hot Water", "Heat"), raw Modbus
+        numbers (20, 30), and MyUplink enum text. Unknown or unavailable
+        values return None so the pattern-based status reads stay untouched
+        (MyUplink priority ids/texts are not fully documented).
+
+        Returns:
+            "hot_water", "heating", "other", or None when unavailable/unknown
+        """
+        prio_entity = self._entity_cache.get("prio")
+        if not prio_entity:
+            return None
+
+        state = self.hass.states.get(prio_entity)
+        if not state or state.state in ["unknown", "unavailable"]:
+            return None
+
+        prio_lower = state.state.lower()
+        if prio_lower in NIBE_PRIO_HOT_WATER_STATES:
+            return "hot_water"
+        if prio_lower in NIBE_PRIO_HEATING_STATES:
+            return "heating"
+        return "other"
 
     def _estimate_degree_minutes(
         self, indoor_temp: float, supply_temp: float, outdoor_temp: float

--- a/custom_components/effektguard/config_flow.py
+++ b/custom_components/effektguard/config_flow.py
@@ -26,9 +26,64 @@ from .const import (
     DEFAULT_HEAT_PUMP_MODEL,
     DEFAULT_INDOOR_TEMP_METHOD,
     DOMAIN,
+    NIBE_DISCOVERY_PATTERNS,
+    NIBE_MANUAL_OVERRIDE_KEYS,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Entity fields users may set, clear, or leave on auto-discovery.
+# Selectors allow sensor/number/input_number because local NIBE sources
+# (nibe_heatpump, MyUplink) expose writable values as NUMBER entities and
+# generic Modbus setups wrap registers in template numbers (issue #18).
+SOURCE_ENTITY_DOMAINS = ["sensor", "number", "input_number"]
+
+# Manual override fields shown in optional_sensors and reconfigure
+# (single source of truth: the adapter's override map in const.py)
+MANUAL_SENSOR_OVERRIDE_FIELDS: tuple[str, ...] = tuple(NIBE_MANUAL_OVERRIDE_KEYS.values())
+
+# Heat pump model choices (setup step "model" and reconfigure)
+HEAT_PUMP_MODEL_OPTIONS: dict[str, str] = {
+    "nibe_f730": "NIBE F730 (6kW ASHP)",
+    "nibe_f750": "NIBE F750 (8kW ASHP - Most Common)",
+    "nibe_f1155": "NIBE F1155 (GSHP)",
+    "nibe_f2040": "NIBE F2040 (12-16kW ASHP)",
+    "nibe_s1155": "NIBE S1155 (GSHP)",
+}
+
+
+def _optional_entity_field(
+    schema_dict: dict[Any, Any],
+    conf_key: str,
+    entity_selector: selector.EntitySelector,
+    suggested: str | list[str] | None,
+) -> None:
+    """Add an optional entity selector that can be cleared by the user.
+
+    Uses suggested_value instead of default: a voluptuous default is re-applied
+    when the field is emptied, which makes stored entities impossible to clear.
+    """
+    if suggested:
+        key = vol.Optional(conf_key, description={"suggested_value": suggested})
+    else:
+        key = vol.Optional(conf_key)
+    schema_dict[key] = entity_selector
+
+
+def _manual_override_schema(schema_dict: dict[Any, Any], current: dict[str, Any]) -> None:
+    """Add the manual sensor-override fields to a schema dict.
+
+    Overrides beat name-pattern discovery in the adapter. Domain filtering is
+    deliberately loose (no device_class requirement): Modbus setups often lack
+    device_class metadata, and these fields exist precisely for such setups.
+    """
+    for conf_key in MANUAL_SENSOR_OVERRIDE_FIELDS:
+        _optional_entity_field(
+            schema_dict,
+            conf_key,
+            selector.EntitySelector(selector.EntitySelectorConfig(domain=SOURCE_ENTITY_DOMAINS)),
+            current.get(conf_key),
+        )
 
 
 class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -69,8 +124,10 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         else:
             info_msg = (
                 "No NIBE offset entities auto-detected. "
-                "If MyUplink just loaded, wait a moment and try again. "
-                "Otherwise, manually select the number.* entity for heating curve offset control."
+                "If your NIBE integration (MyUplink, nibe_heatpump, Modbus) just "
+                "loaded, wait a moment and try again. Otherwise, manually select "
+                "the number entity that controls the heating curve offset "
+                "(register 47011 on F-series)."
             )
 
         return self.async_show_form(
@@ -174,14 +231,7 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(
                         CONF_HEAT_PUMP_MODEL,
                         default=DEFAULT_HEAT_PUMP_MODEL,
-                    ): vol.In(
-                        {
-                            "nibe_f730": "NIBE F730 (6kW ASHP)",
-                            "nibe_f750": "NIBE F750 (8kW ASHP - Most Common)",
-                            "nibe_f2040": "NIBE F2040 (12-16kW ASHP)",
-                            "nibe_s1155": "NIBE S1155 (GSHP)",
-                        }
-                    ),
+                    ): vol.In(HEAT_PUMP_MODEL_OPTIONS),
                 }
             ),
             errors=errors,
@@ -239,6 +289,8 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._data[CONF_INDOOR_TEMP_METHOD] = user_input.get(
                 CONF_INDOOR_TEMP_METHOD, DEFAULT_INDOOR_TEMP_METHOD
             )
+            for conf_key in MANUAL_SENSOR_OVERRIDE_FIELDS:
+                self._data[conf_key] = user_input.get(conf_key)
 
             # Create entry
             return self.async_create_entry(
@@ -260,55 +312,35 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema_dict: dict[Any, Any] = {}
 
-        # Degree minutes sensor (optional)
-        if auto_detected_dm:
-            schema_dict[vol.Optional(CONF_DEGREE_MINUTES_ENTITY, default=auto_detected_dm)] = (
-                selector.EntitySelector(
-                    selector.EntitySelectorConfig(
-                        domain="sensor",
-                    )
-                )
-            )
-        else:
-            schema_dict[vol.Optional(CONF_DEGREE_MINUTES_ENTITY)] = selector.EntitySelector(
-                selector.EntitySelectorConfig(
-                    domain="sensor",
-                )
-            )
+        # Degree minutes (optional) - a NUMBER entity on nibe_heatpump/MyUplink
+        # (writable register), a sensor on generic Modbus setups (issue #18)
+        _optional_entity_field(
+            schema_dict,
+            CONF_DEGREE_MINUTES_ENTITY,
+            selector.EntitySelector(selector.EntitySelectorConfig(domain=SOURCE_ENTITY_DOMAINS)),
+            auto_detected_dm,
+        )
 
         # Power meter sensor (optional)
-        if auto_detected_power:
-            schema_dict[vol.Optional(CONF_POWER_SENSOR_ENTITY, default=auto_detected_power)] = (
-                selector.EntitySelector(
-                    selector.EntitySelectorConfig(
-                        domain="sensor",
-                        device_class="power",
-                    )
-                )
-            )
-        else:
-            schema_dict[vol.Optional(CONF_POWER_SENSOR_ENTITY)] = selector.EntitySelector(
+        _optional_entity_field(
+            schema_dict,
+            CONF_POWER_SENSOR_ENTITY,
+            selector.EntitySelector(
                 selector.EntitySelectorConfig(
                     domain="sensor",
                     device_class="power",
                 )
-            )
+            ),
+            auto_detected_power,
+        )
 
         # Temporary lux switch (DHW control, optional)
-        if auto_detected_temp_lux:
-            schema_dict[vol.Optional(CONF_NIBE_TEMP_LUX_ENTITY, default=auto_detected_temp_lux)] = (
-                selector.EntitySelector(
-                    selector.EntitySelectorConfig(
-                        domain="switch",
-                    )
-                )
-            )
-        else:
-            schema_dict[vol.Optional(CONF_NIBE_TEMP_LUX_ENTITY)] = selector.EntitySelector(
-                selector.EntitySelectorConfig(
-                    domain="switch",
-                )
-            )
+        _optional_entity_field(
+            schema_dict,
+            CONF_NIBE_TEMP_LUX_ENTITY,
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+            auto_detected_temp_lux,
+        )
 
         # Additional indoor temperature sensors (optional, multi-select)
         schema_dict[vol.Optional(CONF_ADDITIONAL_INDOOR_SENSORS)] = selector.EntitySelector(
@@ -318,6 +350,10 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 multiple=True,
             )
         )
+
+        # Manual overrides for core NIBE sensors - required when name-pattern
+        # discovery cannot find them (generic Modbus, renamed entities)
+        _manual_override_schema(schema_dict, self._data)
 
         # Indoor temperature calculation method
         schema_dict[vol.Optional(CONF_INDOOR_TEMP_METHOD, default=DEFAULT_INDOOR_TEMP_METHOD)] = (
@@ -348,35 +384,23 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _discover_nibe_entities(self) -> list[str]:
         """Discover NIBE heating curve offset entities.
 
-        Filters for entities that can control heating curve offset:
-        - number.* entities with 'offset' in name from MyUplink integration
-        - OR number.* entities with 'offset' in name AND 'nibe' in entity_id
-        - Excludes entities with translation errors
+        Filters for writable number entities matching the shared offset
+        patterns (const.NIBE_DISCOVERY_PATTERNS). Source-neutral: MyUplink,
+        nibe_heatpump, and template numbers wrapping Modbus writes all qualify
+        (issue #18).
         """
         entities = []
-        ent_reg = er.async_get(self.hass)
+        # Count only NIBE-specific patterns: the bare "offset" pattern would
+        # count unrelated calibration numbers (TRV/Tado temperature offsets)
+        # and mislead the "Found N" message. The selector itself stays open.
+        offset_patterns = [p for p in NIBE_DISCOVERY_PATTERNS["offset"] if p != "offset"]
 
-        for state in self.hass.states.async_all():
+        for state in self.hass.states.async_all("number"):
             entity_id = state.entity_id
+            entity_lower = entity_id.lower()
 
-            # Must be a number entity (writable)
-            if not entity_id.startswith("number."):
-                continue
-
-            # Must be related to offset/curve control
-            if "offset" not in entity_id.lower():
-                continue
-
-            # Check if entity is from MyUplink integration (preferred method)
-            entity_entry = ent_reg.async_get(entity_id)
-            if entity_entry and entity_entry.platform == "myuplink":
-                # MyUplink entity with offset - this is what we want!
-                pass
-            elif "nibe" in entity_id.lower() or "myuplink" in entity_id.lower():
-                # Fallback: entity_id contains nibe/myuplink (older naming patterns)
-                pass
-            else:
-                # Not a NIBE/MyUplink entity
+            # Must be related to NIBE offset/curve control
+            if not any(pattern in entity_lower for pattern in offset_patterns):
                 continue
 
             # Exclude entities with translation errors
@@ -439,13 +463,16 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return entities
 
     def _discover_degree_minutes_entities(self) -> list[str]:
-        """Discover NIBE degree minutes sensors.
+        """Discover NIBE degree minutes entities.
+
+        Scans sensor AND number domains: nibe_heatpump and MyUplink expose
+        degree minutes as a writable NUMBER entity (register 43005/40940),
+        generic Modbus setups as a sensor (issue #18).
 
         Auto-detect common patterns:
-        - sensor.*gradminuter* (Swedish)
-        - sensor.*degree_minutes*
-        - sensor.*gm_* (abbreviation)
-        - NIBE specific entity patterns
+        - *gradminuter* (Swedish)
+        - *degree_minutes*
+        - *_gm_* / *_dm_* (abbreviations, requires NIBE-related entity id)
         """
         entities = []
         search_terms = [
@@ -456,22 +483,27 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "_dm_",
         ]
 
-        for state in self.hass.states.async_all():
-            entity_id = state.entity_id
-            if not entity_id.startswith("sensor."):
-                continue
+        ent_reg = er.async_get(self.hass)
 
+        for state in self.hass.states.async_all(("sensor", "number")):
+            entity_id = state.entity_id
             entity_lower = entity_id.lower()
 
             # Check for any search term in entity ID
             for term in search_terms:
                 if term in entity_lower:
-                    # Additional validation: check if NIBE-related
-                    if "nibe" in entity_lower or "myuplink" in entity_lower:
+                    # Explicit degree-minutes name is always accepted
+                    if "gradminuter" in entity_lower or "degree_minute" in entity_lower:
                         entities.append(entity_id)
                         break
-                    # Or if it's explicitly a degree minutes sensor
-                    elif "gradminuter" in entity_lower or "degree_minute" in entity_lower:
+                    # Abbreviations (_gm_/_dm_) need a NIBE source to avoid
+                    # false positives. MyUplink ids carry the DEVICE name, not
+                    # "myuplink", so check the registry platform, with the
+                    # name substring as fallback for renamed entities.
+                    entity_entry = ent_reg.async_get(entity_id)
+                    if (
+                        entity_entry and entity_entry.platform in ("myuplink", "nibe_heatpump")
+                    ) or ("nibe" in entity_lower):
                         entities.append(entity_id)
                         break
 
@@ -549,22 +581,33 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             is_temp_lux = (
                 ("temporary" in entity_lower and "lux" in entity_lower)
                 or ("temp" in entity_lower and "lux" in entity_lower)
-                or "50004" in entity_lower  # NIBE parameter ID
+                or "50004" in entity_lower  # MyUplink parameter ID
+                or "48132" in entity_lower  # F-series Modbus register
             )
 
             if not is_temp_lux:
                 continue
 
-            # Verify it's from MyUplink integration or NIBE-related
+            # Verify it's from a NIBE source integration or NIBE-related by name
             entity_entry = ent_reg.async_get(entity_id)
-            if entity_entry and entity_entry.platform == "myuplink":
-                # Confirmed MyUplink entity
+            if entity_entry and entity_entry.platform in ("myuplink", "nibe_heatpump"):
                 entities.append(entity_id)
             elif any(
                 term in entity_lower
-                for term in ["nibe", "myuplink", "f750", "f470", "f1145", "f1245", "f1255", "s1155"]
+                for term in [
+                    "nibe",
+                    "myuplink",
+                    "f750",
+                    "f470",
+                    "f1145",
+                    "f1155",
+                    "f1245",
+                    "f1255",
+                    "s1155",
+                    "48132",
+                ]
             ):
-                # Entity ID contains NIBE model numbers or myuplink
+                # Entity ID contains NIBE model numbers, register, or source name
                 entities.append(entity_id)
 
         return entities
@@ -574,62 +617,107 @@ class EffektGuardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle reconfiguration of entity selections.
 
-        Allows users to change entity selections (weather, power sensor, etc.)
-        without recreating the entire integration.
+        Allows users to change entity selections (offset control, weather,
+        power sensor, manual sensor overrides, etc.) without recreating the
+        entire integration. Fields left empty are cleared (back to
+        auto-discovery); the offset entity keeps its previous value when left
+        empty because the integration cannot work without one.
         """
         errors = {}
+        entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            # Update entry.data with new entity selections and reload
-            return self.async_update_reload_and_abort(
-                self._get_reconfigure_entry(),
-                data_updates=user_input,
-            )
+            # Explicit None for absent optional fields so clearing works;
+            # async_update_reload_and_abort merges data_updates over entry.data
+            data_updates: dict[str, Any] = {
+                CONF_WEATHER_ENTITY: user_input.get(CONF_WEATHER_ENTITY),
+                CONF_DEGREE_MINUTES_ENTITY: user_input.get(CONF_DEGREE_MINUTES_ENTITY),
+                CONF_POWER_SENSOR_ENTITY: user_input.get(CONF_POWER_SENSOR_ENTITY),
+                CONF_NIBE_TEMP_LUX_ENTITY: user_input.get(CONF_NIBE_TEMP_LUX_ENTITY),
+                CONF_ADDITIONAL_INDOOR_SENSORS: user_input.get(CONF_ADDITIONAL_INDOOR_SENSORS, []),
+            }
+            for conf_key in MANUAL_SENSOR_OVERRIDE_FIELDS:
+                data_updates[conf_key] = user_input.get(conf_key)
 
-        # Get current entity selections from entry.data
-        entry = self._get_reconfigure_entry()
+            # Model and offset entity are required - keep old values if empty
+            if user_input.get(CONF_HEAT_PUMP_MODEL):
+                data_updates[CONF_HEAT_PUMP_MODEL] = user_input[CONF_HEAT_PUMP_MODEL]
+
+            nibe_entity = user_input.get(CONF_NIBE_ENTITY)
+            if nibe_entity:
+                if not self.hass.states.get(nibe_entity):
+                    errors["base"] = "nibe_entity_not_found"
+                else:
+                    data_updates[CONF_NIBE_ENTITY] = nibe_entity
+
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates=data_updates,
+                )
+
+        schema_dict: dict[Any, Any] = {}
+
+        _optional_entity_field(
+            schema_dict,
+            CONF_NIBE_ENTITY,
+            selector.EntitySelector(selector.EntitySelectorConfig(domain=["number"])),
+            entry.data.get(CONF_NIBE_ENTITY),
+        )
+        # Model uses default= (not suggested_value): it must never be cleared,
+        # an empty submit keeps the stored model
+        schema_dict[
+            vol.Optional(
+                CONF_HEAT_PUMP_MODEL,
+                default=entry.data.get(CONF_HEAT_PUMP_MODEL, DEFAULT_HEAT_PUMP_MODEL),
+            )
+        ] = vol.In(HEAT_PUMP_MODEL_OPTIONS)
+        _optional_entity_field(
+            schema_dict,
+            CONF_WEATHER_ENTITY,
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="weather")),
+            entry.data.get(CONF_WEATHER_ENTITY),
+        )
+        _optional_entity_field(
+            schema_dict,
+            CONF_DEGREE_MINUTES_ENTITY,
+            selector.EntitySelector(selector.EntitySelectorConfig(domain=SOURCE_ENTITY_DOMAINS)),
+            entry.data.get(CONF_DEGREE_MINUTES_ENTITY),
+        )
+        _optional_entity_field(
+            schema_dict,
+            CONF_POWER_SENSOR_ENTITY,
+            selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain="sensor",
+                    device_class="power",
+                )
+            ),
+            entry.data.get(CONF_POWER_SENSOR_ENTITY),
+        )
+        _optional_entity_field(
+            schema_dict,
+            CONF_NIBE_TEMP_LUX_ENTITY,
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+            entry.data.get(CONF_NIBE_TEMP_LUX_ENTITY),
+        )
+        _optional_entity_field(
+            schema_dict,
+            CONF_ADDITIONAL_INDOOR_SENSORS,
+            selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain="sensor",
+                    device_class="temperature",
+                    multiple=True,
+                )
+            ),
+            entry.data.get(CONF_ADDITIONAL_INDOOR_SENSORS, []),
+        )
+        _manual_override_schema(schema_dict, dict(entry.data))
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_WEATHER_ENTITY,
-                        default=entry.data.get(CONF_WEATHER_ENTITY),
-                    ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(
-                            domain="weather",
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_DEGREE_MINUTES_ENTITY,
-                        default=entry.data.get(CONF_DEGREE_MINUTES_ENTITY),
-                    ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(
-                            domain="sensor",
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_POWER_SENSOR_ENTITY,
-                        default=entry.data.get(CONF_POWER_SENSOR_ENTITY),
-                    ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(
-                            domain="sensor",
-                            device_class="power",
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_ADDITIONAL_INDOOR_SENSORS,
-                        default=entry.data.get(CONF_ADDITIONAL_INDOOR_SENSORS, []),
-                    ): selector.EntitySelector(
-                        selector.EntitySelectorConfig(
-                            domain="sensor",
-                            device_class="temperature",
-                            multiple=True,
-                        )
-                    ),
-                }
-            ),
+            data_schema=vol.Schema(schema_dict),
             errors=errors,
             description_placeholders={
                 "info": "Change entity selections. Integration will reload automatically."

--- a/custom_components/effektguard/const.py
+++ b/custom_components/effektguard/const.py
@@ -13,7 +13,15 @@ CONF_GESPOT_ENTITY: Final = "gespot_entity"
 CONF_WEATHER_ENTITY: Final = "weather_entity"
 CONF_DEGREE_MINUTES_ENTITY: Final = "degree_minutes_entity"  # Optional: NIBE degree minutes
 CONF_POWER_SENSOR_ENTITY: Final = "power_sensor_entity"  # Optional: Power meter
-CONF_DHW_TEMP_ENTITY: Final = "dhw_temp_entity"  # Optional: DHW temperature sensor (BT7)
+CONF_DHW_TEMP_ENTITY: Final = "dhw_temp_entity"  # Optional: DHW top temperature sensor (BT7)
+# Manual sensor overrides for setups where name-pattern discovery cannot work
+# (generic Modbus YAML, renamed entities, nibe_heatpump with re-added entries).
+# Issue #18: local Modbus/nibe_heatpump users need these; discovery is fallback only.
+CONF_OUTDOOR_TEMP_ENTITY: Final = "outdoor_temp_entity"  # Optional: BT1 override
+CONF_INDOOR_TEMP_ENTITY: Final = "indoor_temp_entity"  # Optional: BT50/room sensor override
+CONF_SUPPLY_TEMP_ENTITY: Final = "supply_temp_entity"  # Optional: BT2/BT25/BT63 override
+CONF_RETURN_TEMP_ENTITY: Final = "return_temp_entity"  # Optional: BT3 override
+CONF_DHW_CHARGING_TEMP_ENTITY: Final = "dhw_charging_temp_entity"  # Optional: BT6 override
 CONF_NIBE_TEMP_LUX_ENTITY: Final = "nibe_temp_lux_entity"  # Optional: switch.temporary_lux_50004
 CONF_ENABLE_DHW_OPTIMIZATION: Final = "enable_dhw_optimization"  # Enable intelligent DHW scheduling
 CONF_DHW_DEMAND_PERIODS: Final = "dhw_demand_periods"  # High DHW demand periods (JSON list)
@@ -1106,6 +1114,141 @@ NIBE_DEFAULT_SUPPLY_TEMP: Final = 35.0  # °C - Default supply/flow temp when se
 NIBE_FRACTIONAL_ACCUMULATOR_THRESHOLD: Final = (
     1.0  # °C - Write to NIBE when accumulator crosses ±1.0
 )
+
+# NIBE source-entity discovery patterns (issue #18: multi-source support)
+# EffektGuard reads NIBE data from entities created by ANY of these integrations:
+#   - myuplink (cloud): sensor.<system>_current_outd_temp_bt1,
+#     number.<system>_degree_minutes, number.<system>_heating_offset_climate_system_1
+#     (writable parameters are NUMBER entities; ids carry names, not parameter ids)
+#   - nibe_heatpump (local NibeGW/Modbus): ids from yozik04/nibe coil names, e.g.
+#     sensor.bt1_outdoor_temperature_40004, number.degree_minutes_16_bit_43005,
+#     number.heat_offset_s1_47011 (writable coils are NUMBER entities)
+#   - generic modbus YAML + template numbers (user-defined names)
+# Matching: lowercase substring of entity_id; keys are tried in dict order and each
+# entity satisfies at most ONE key, so specific temperature keys MUST come before
+# broad status keys (e.g. sensor.*_hot_water_top_bt7 belongs to dhw_top_temp, not
+# hot_water_status).
+# Register references (yozik04/nibe f1155_f1255 map; F-series register ids double
+# as MyUplink parameter ids): BT1=40004, BT2=40008, BT3=40012, BT7=40013, BT6=40014,
+# BT50=40033, BT25=40071, DM=40940 (32-bit)/43005 (16-bit, Modbus), offset S1=47011,
+# compressor state=43427, compressor frequency=43136, BE1/BE2/BE3=40083/40081/40079.
+# 40941 is MyUplink's DM id on some models (second word of 40940).
+NIBE_DISCOVERY_PATTERNS: Final[dict[str, list[str]]] = {
+    "outdoor_temp": ["_bt1", "bt1_", "outdoor_temp", "outd_temp", "40004"],
+    # NOTE: no short "room_temp" - "bedroom_temp" etc. contain it as a
+    # substring; BT50-suffixed ids (nibe_heatpump/myuplink) match via _bt50
+    "indoor_temp": ["_bt50", "bt50_", "room_temperature", "40033"],
+    # NOTE: no bare "_bt2"/"bt2_" - it would substring-match BT20/BT21/BT22
+    # exhaust-air sensors; BT2 entities are covered by "supply_temp"
+    # (nibe_heatpump bt2_supply_temp_s1_40008) and "supply_line" (MyUplink)
+    "supply_temp": [
+        "_bt25",
+        "bt25_",
+        "_bt63",
+        "bt63_",
+        "supply_temp",
+        "supply_line",
+        "heating_medium_supply",
+        "40008",
+        "40071",
+    ],
+    "return_temp": ["_bt3", "bt3_", "return_temp", "return_line", "40012"],
+    "dhw_top_temp": ["_bt7", "bt7_", "hw_top", "hot_water_top", "40013"],
+    "dhw_charging_temp": [
+        "_bt6",
+        "bt6_",
+        "hw_bottom",
+        "hw_charging",
+        "hw_load",
+        "hot_water_charging",
+        "40014",
+    ],
+    "degree_minutes": ["degree_minutes", "gradminuter", "40940", "43005", "40941"],
+    "offset": ["heat_offset", "heating_offset", "offset", "47011"],
+    "compressor_hz": ["compressor_frequency", "43136"],
+    "compressor_status": ["compressor_state", "status_compressor", "compressor_status", "43427"],
+    "phase1_current": ["current_be1", "_be1", "phase_1_current", "40083"],
+    "phase2_current": ["current_be2", "_be2", "phase_2_current", "40081"],
+    "phase3_current": ["current_be3", "_be3", "phase_3_current", "40079"],
+    "dhw_amount": ["hot_water_amount", "hw_amount"],
+    "hot_water_status": ["hot_water", "dhw"],
+}
+
+# Entity-id substrings that must never be matched by discovery
+# 47394 = MyUplink "control room sensor syst" (configuration, not a temperature)
+# (EffektGuard's own entities are excluded by registry platform, not by name)
+NIBE_DISCOVERY_EXCLUDE: Final[list[str]] = ["47394", "control_room_sensor"]
+
+# Keys that trigger re-discovery on the update cycle while missing.
+# Source integrations (modbus, nibe_heatpump, myuplink) may create their
+# entities AFTER EffektGuard's first discovery pass during HA startup.
+NIBE_DISCOVERY_CORE_KEYS: Final[tuple[str, ...]] = ("outdoor_temp", "indoor_temp", "supply_temp")
+
+# Re-discover fast for this many attempts, then fall back to a slow retry
+# so a source integration appearing hours after HA start is still picked up
+# without rescanning every cycle forever when a sensor genuinely does not
+# exist (e.g. no BT50 room sensor - a legitimate configuration).
+NIBE_DISCOVERY_MAX_ATTEMPTS: Final = 12
+NIBE_DISCOVERY_SLOW_RETRY_CYCLES: Final = 6  # every 6th update cycle (~30 min)
+
+# Cache keys that must be temperature sensors (validated by device_class/unit)
+NIBE_TEMPERATURE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "outdoor_temp",
+        "indoor_temp",
+        "supply_temp",
+        "return_temp",
+        "dhw_top_temp",
+        "dhw_charging_temp",
+    }
+)
+
+# Discovery candidate ranks: lower wins. Manual overrides always win; a live
+# entity backed by the entity registry (a real integration) beats a live
+# entity without a registry entry (template/MQTT/modbus YAML lookalikes),
+# which beats a registry entry without a state yet (stale/still-loading
+# entries otherwise win by iteration order and read as defaults forever).
+NIBE_DISCOVERY_RANK_MANUAL: Final = -1
+NIBE_DISCOVERY_RANK_LIVE: Final = 0
+NIBE_DISCOVERY_RANK_LIVE_UNREGISTERED: Final = 1
+NIBE_DISCOVERY_RANK_REGISTRY_ONLY: Final = 2
+
+# Switch entity discovery (separate domain scan)
+NIBE_SWITCH_DISCOVERY_PATTERNS: Final[dict[str, list[str]]] = {
+    "increased_ventilation": ["increased_ventilation"],
+}
+
+# Cache keys that hold manual config-flow overrides (override beats discovery)
+# Maps discovery cache key -> CONF_* config key
+NIBE_MANUAL_OVERRIDE_KEYS: Final[dict[str, str]] = {
+    "outdoor_temp": CONF_OUTDOOR_TEMP_ENTITY,
+    "indoor_temp": CONF_INDOOR_TEMP_ENTITY,
+    "supply_temp": CONF_SUPPLY_TEMP_ENTITY,
+    "return_temp": CONF_RETURN_TEMP_ENTITY,
+    "dhw_top_temp": CONF_DHW_TEMP_ENTITY,
+    "dhw_charging_temp": CONF_DHW_CHARGING_TEMP_ENTITY,
+}
+
+# Sensor states that mean "no valid reading": -32768 is the s16 unknown-value
+# marker (MyUplink API and disconnected Modbus sensors); -3276.8 is the same
+# marker after the common x10 scale factor. Treated as unavailable.
+NIBE_UNKNOWN_VALUE_MARKERS: Final[frozenset[float]] = frozenset({-32768.0, -3276.8})
+
+# Re-sync the tracked offset from the entity when it disagrees and no
+# write happened within this window (external change or failed write)
+NIBE_OFFSET_RESYNC_MINUTES: Final = 15
+
+# States treated as "active" when reading status entities.
+# Covers on/off style states plus nibe_heatpump mapped coil states
+# ("Running"/"Starting" from compressor state 43427). Compared lowercase.
+NIBE_STATUS_ACTIVE_STATES: Final[frozenset[str]] = frozenset(
+    {"on", "true", "1", "yes", "running", "starting"}
+)
+
+# Compressor frequency above this means the compressor is running.
+# Used to derive is_heating when no parseable status entity exists
+# (raw Modbus 43427 is a numeric enum: 20=Stopped 40=Starting 60=Running).
+NIBE_COMPRESSOR_ACTIVE_HZ_THRESHOLD: Final = 1.0  # Hz
 
 # DHW Recovery Time Estimation
 # DM recovery rates based on heat pump efficiency at different outdoor temperatures

--- a/custom_components/effektguard/const.py
+++ b/custom_components/effektguard/const.py
@@ -1128,10 +1128,12 @@ NIBE_FRACTIONAL_ACCUMULATOR_THRESHOLD: Final = (
 # entity satisfies at most ONE key, so specific temperature keys MUST come before
 # broad status keys (e.g. sensor.*_hot_water_top_bt7 belongs to dhw_top_temp, not
 # hot_water_status).
-# Register references (yozik04/nibe f1155_f1255 map; F-series register ids double
-# as MyUplink parameter ids): BT1=40004, BT2=40008, BT3=40012, BT7=40013, BT6=40014,
+# Register references (yozik04/nibe, file nibe/data/f1155_f1255.json — the map
+# HA's nibe_heatpump integration uses; F-series register ids double as MyUplink
+# parameter ids): BT1=40004, BT2=40008, BT3=40012, BT7=40013, BT6=40014,
 # BT50=40033, BT25=40071, DM=40940 (32-bit)/43005 (16-bit, Modbus), offset S1=47011,
-# compressor state=43427, compressor frequency=43136, BE1/BE2/BE3=40083/40081/40079.
+# compressor state=43427, compressor frequency=43136, prio=43086,
+# BE1/BE2/BE3=40083/40081/40079.
 # 40941 is MyUplink's DM id on some models (second word of 40940).
 NIBE_DISCOVERY_PATTERNS: Final[dict[str, list[str]]] = {
     "outdoor_temp": ["_bt1", "bt1_", "outdoor_temp", "outd_temp", "40004"],
@@ -1167,6 +1169,8 @@ NIBE_DISCOVERY_PATTERNS: Final[dict[str, list[str]]] = {
     "offset": ["heat_offset", "heating_offset", "offset", "47011"],
     "compressor_hz": ["compressor_frequency", "43136"],
     "compressor_status": ["compressor_state", "status_compressor", "compressor_status", "43427"],
+    # "prio" also matches "priority" (MyUplink naming) as a substring
+    "prio": ["prio", "43086"],
     "phase1_current": ["current_be1", "_be1", "phase_1_current", "40083"],
     "phase2_current": ["current_be2", "_be2", "phase_2_current", "40081"],
     "phase3_current": ["current_be3", "_be3", "phase_3_current", "40079"],
@@ -1244,6 +1248,17 @@ NIBE_OFFSET_RESYNC_MINUTES: Final = 15
 NIBE_STATUS_ACTIVE_STATES: Final[frozenset[str]] = frozenset(
     {"on", "true", "1", "yes", "running", "starting"}
 )
+
+# Priority register 43086 identifies what the compressor is serving:
+# 10=Off, 20=Hot Water, 30=Heat, 40=Pool, 41=Pool 2, 50=Transfer, 60=Cooling
+# (yozik04/nibe, nibe/data/f1155_f1255.json). nibe_heatpump exposes the mapped
+# strings, raw Modbus the numbers, MyUplink its own enum text. A run with
+# hot-water priority must NOT count as space heating. Compared lowercase;
+# unknown values leave the pattern-based status reads untouched.
+NIBE_PRIO_HOT_WATER_STATES: Final[frozenset[str]] = frozenset(
+    {"hot water", "hot_water", "20", "20.0"}
+)
+NIBE_PRIO_HEATING_STATES: Final[frozenset[str]] = frozenset({"heat", "heating", "30", "30.0"})
 
 # Compressor frequency above this means the compressor is running.
 # Used to derive is_heating when no parseable status entity exists

--- a/custom_components/effektguard/coordinator.py
+++ b/custom_components/effektguard/coordinator.py
@@ -943,6 +943,15 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
             # During startup, don't track decisions - they're not being applied
             # The tracker will be initialized with actual NIBE offset when startup completes
             pass
+        elif decision.is_manual_override:
+            # User-commanded offsets (force_offset/boost services) are
+            # authoritative — the volatile blocker must never defer an
+            # explicit user command for 45 minutes
+            _LOGGER.info(
+                "Manual override: bypassing volatile check (offset → %.1f°C)",
+                decision.offset,
+            )
+            self._offset_volatility_tracker.record_change(decision.offset, decision.reasoning)
         elif decision.anti_windup_active:
             # Anti-windup is a safety mechanism — always apply immediately
             # Record the change so volatile tracker knows the new baseline

--- a/custom_components/effektguard/coordinator.py
+++ b/custom_components/effektguard/coordinator.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -48,12 +49,8 @@ from .const import (
     STARTUP_GRACE_UPDATES,
     UPDATE_INTERVAL_MINUTES,
 )
-from .models.nibe import (
-    NibeF2040Profile,
-    NibeF730Profile,
-    NibeF750Profile,
-    NibeS1155Profile,
-)
+from .models.nibe import NibeF750Profile
+from .models.registry import HeatPumpModelRegistry
 from .optimization.adaptive_learning import AdaptiveThermalModel
 from .optimization.airflow_optimizer import AirflowOptimizer
 from .optimization.decision_engine import (
@@ -77,15 +74,6 @@ if TYPE_CHECKING:
     from .models.types import EffektGuardConfigDict
 
 _LOGGER = logging.getLogger(__name__)
-
-
-# Model registry for quick lookup
-HEAT_PUMP_MODELS = {
-    "nibe_f730": NibeF730Profile,
-    "nibe_f750": NibeF750Profile,
-    "nibe_f2040": NibeF2040Profile,
-    "nibe_s1155": NibeS1155Profile,
-}
 
 
 class EffektGuardCoordinator(DataUpdateCoordinator):
@@ -127,11 +115,19 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
         self.effect = effect_manager
         self.entry = entry
 
-        # Load heat pump model profile
+        # Load heat pump model profile from the single registry
+        # (models self-register via decorator in models/nibe/)
         model_key = entry.data.get(CONF_HEAT_PUMP_MODEL, DEFAULT_HEAT_PUMP_MODEL)
-        model_class = HEAT_PUMP_MODELS.get(model_key, NibeF750Profile)
-        # type: ignore - concrete profile dataclasses have defaults
-        self.heat_pump_model = model_class()  # type: ignore[call-arg]
+        try:
+            self.heat_pump_model = HeatPumpModelRegistry.get_model(model_key)
+        except ValueError:
+            _LOGGER.warning(
+                "Unknown heat pump model '%s', falling back to %s - "
+                "check the heat pump model setting",
+                model_key,
+                DEFAULT_HEAT_PUMP_MODEL,
+            )
+            self.heat_pump_model = NibeF750Profile()  # type: ignore[call-arg]
 
         _LOGGER.info(
             "Loaded heat pump model: %s (%s)",
@@ -741,7 +737,7 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
             # Gracefully handle this by returning minimal data until entities are available
             if not self._first_successful_update:
                 _LOGGER.info(
-                    "Waiting for NIBE MyUplink entities to become available: %s "
+                    "Waiting for NIBE entities to become available: %s "
                     "(this is normal during HA startup, will retry in %d minutes)",
                     err,
                     UPDATE_INTERVAL_MINUTES,
@@ -981,8 +977,8 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
         self.current_offset = decision.offset
         self.last_decision_time = dt_util.utcnow()
 
-        # Apply offset to NIBE heat pump via MyUplink integration
-        # This sends the calculated offset to the MyUplink number entity (parameter 47011)
+        # Apply offset to the NIBE heating curve offset number entity
+        # (register 47011 on F-series; MyUplink, nibe_heatpump, or template number)
         # Rate limiting (5 min) handled in nibe_adapter to prevent excessive API calls
         #
         # Accumulation logic: We track fractional offsets but only write to NIBE when
@@ -1004,7 +1000,7 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
             try:
                 was_applied = await self.nibe.set_curve_offset(decision.offset)
                 if was_applied:
-                    _LOGGER.info("Applied offset %.2f°C to NIBE via MyUplink", decision.offset)
+                    _LOGGER.info("Applied offset %.2f°C to NIBE", decision.offset)
                     # Track what NIBE actually has (integer) - synced from entity on restart
                     self.last_applied_offset = float(int(decision.offset))
                     self.last_offset_timestamp = dt_util.utcnow()
@@ -1014,7 +1010,7 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
                         "Offset %.2f°C unchanged (NIBE offset not changed)",
                         decision.offset,
                     )
-            except (AttributeError, OSError, ValueError) as err:
+            except (HomeAssistantError, AttributeError, OSError, ValueError) as err:
                 _LOGGER.error("Failed to apply offset to NIBE: %s", err)
                 # Continue anyway - next cycle will retry
 
@@ -1237,10 +1233,12 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
             # DHW sensor not available - provide basic recommendation
             if nibe_data:
                 _LOGGER.warning(
-                    "DHW sensor (BT7) not found - check MyUplink "
-                    "integration has exposed BT7/40013 sensor"
+                    "DHW sensor (BT7) not found - ensure your NIBE integration "
+                    "exposes the BT7/40013 sensor (enable the entity in "
+                    "nibe_heatpump/MyUplink) or select it manually via "
+                    "Reconfigure in EffektGuard"
                 )
-                dhw_recommendation = "DHW sensor not found - check MyUplink integration"
+                dhw_recommendation = "DHW sensor not found - check NIBE integration"
                 dhw_planning_summary = "DHW sensor not found"
                 dhw_planning_details = {}
             else:
@@ -1664,10 +1662,10 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
                         "switch",
                         "turn_off",
                         {"entity_id": self.temp_lux_entity},
-                        blocking=False,
+                        blocking=True,
                     )
                     self._last_dhw_control_time = now_time
-                except (AttributeError, OSError, ValueError) as err:
+                except (HomeAssistantError, AttributeError, OSError, ValueError) as err:
                     _LOGGER.error("Failed to abort DHW heating: %s", err)
                 return  # Exit early - abort handled
 
@@ -1696,10 +1694,10 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
                     "switch",
                     "turn_on",
                     {"entity_id": self.temp_lux_entity},
-                    blocking=False,
+                    blocking=True,
                 )
                 self._last_dhw_control_time = now_time
-            except (AttributeError, OSError, ValueError) as err:
+            except (HomeAssistantError, AttributeError, OSError, ValueError) as err:
                 _LOGGER.error("Failed to turn on temporary lux: %s", err)
 
         elif not decision.should_heat and is_lux_on:
@@ -1715,10 +1713,10 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
                     "switch",
                     "turn_off",
                     {"entity_id": self.temp_lux_entity},
-                    blocking=False,
+                    blocking=True,
                 )
                 self._last_dhw_control_time = now_time
-            except (AttributeError, OSError, ValueError) as err:
+            except (HomeAssistantError, AttributeError, OSError, ValueError) as err:
                 _LOGGER.error("Failed to turn off temporary lux: %s", err)
         else:
             # No change needed
@@ -1841,7 +1839,7 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
             # In this case, use calculated/estimated heat pump power for peak tracking
             if has_external_power_sensor and current_power < 0.5:
                 # Check if heat pump is actually working hard
-                compressor_hz = getattr(nibe_data, "compressor_frequency", 0)
+                compressor_hz = getattr(nibe_data, "compressor_hz", 0) or 0
                 is_heating = getattr(nibe_data, "is_heating", False)
 
                 if is_heating and compressor_hz > 20:
@@ -1939,7 +1937,7 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
             self.last_offset_timestamp = dt_util.utcnow()
             self._learned_data_changed = True  # Trigger save on shutdown
             _LOGGER.info("Applied offset: %.2f°C", offset)
-        except (AttributeError, OSError, ValueError) as err:
+        except (HomeAssistantError, AttributeError, OSError, ValueError) as err:
             _LOGGER.error("Failed to apply offset: %s", err)
             raise
 
@@ -1958,7 +1956,7 @@ class EffektGuardCoordinator(DataUpdateCoordinator):
             # Reset offset to neutral (0.0)
             try:
                 await self.async_set_offset(0.0)
-            except (AttributeError, OSError, ValueError) as err:
+            except (HomeAssistantError, AttributeError, OSError, ValueError) as err:
                 _LOGGER.error("Failed to reset offset: %s", err)
 
     async def async_update_config(self, options: "EffektGuardConfigDict") -> None:

--- a/custom_components/effektguard/manifest.json
+++ b/custom_components/effektguard/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "effektguard",
   "name": "EffektGuard",
-  "after_dependencies": ["ge_spot", "mqtt", "myuplink", "recorder", "sunspec", "template", "weather"],
+  "after_dependencies": ["ge_spot", "modbus", "mqtt", "myuplink", "nibe_heatpump", "recorder", "sunspec", "template", "weather"],
   "codeowners": ["@enoch85"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/effektguard/models/nibe/__init__.py
+++ b/custom_components/effektguard/models/nibe/__init__.py
@@ -3,18 +3,21 @@
 Supported models:
 - F730: 6kW ASHP (widely used, replaced by F735 in current lineup)
 - F750: 8kW ASHP (widely used, not in current NIBE lineup)
+- F1155: 4-12kW GSHP mid-range (F-series, local Modbus/NibeGW users - issue #18)
 - F2040: 12-16kW ASHP (widely used, not in current NIBE lineup)
 - S1155: 3-12kW GSHP mid-range (VERIFIED - current NIBE model)
 """
 
 from .f730 import NibeF730Profile
 from .f750 import NibeF750Profile
+from .f1155 import NibeF1155Profile
 from .f2040 import NibeF2040Profile
 from .s1155 import NibeS1155Profile
 
 __all__ = [
     "NibeF730Profile",
     "NibeF750Profile",
+    "NibeF1155Profile",
     "NibeF2040Profile",
     "NibeS1155Profile",
 ]

--- a/custom_components/effektguard/models/nibe/f1155.py
+++ b/custom_components/effektguard/models/nibe/f1155.py
@@ -1,0 +1,59 @@
+"""NIBE F1155 heat pump profile.
+
+Inverter-controlled GSHP - F-series ground source, predecessor of the S1155.
+Available in 3 sizes: 1.5-6 kW, 4-12 kW, 4-16 kW.
+
+Added for issue #18: F1155 owners connect via local Modbus (nibe_heatpump
+integration / MODBUS40) and previously had to pick the S1155 profile.
+
+Source: https://www.nibe.eu/en-eu/products/heat-pumps/ground-source-heat-pumps
+Physics inherit from the S1155 (same GSHP family, stable 5-8°C ground
+temperature); COP curve set slightly below the S1155 (older inverter
+platform, SCOP ~5.0).
+"""
+
+from dataclasses import dataclass
+
+from ..registry import HeatPumpModelRegistry
+from .s1155 import NibeS1155Profile
+
+
+@HeatPumpModelRegistry.register("nibe_f1155")
+@dataclass
+class NibeF1155Profile(NibeS1155Profile):
+    """NIBE F1155 Ground Source Heat Pump (Inverter-controlled).
+
+    **Available Sizes**: 1.5-6 kW, 4-12 kW, 4-16 kW
+    **Target Market**: Small to large properties with ground source installation
+    **Technology**: Inverter-controlled compressor, adjusts to heating demand
+    **Key Advantage**: Stable ground temperature (5-8°C year-round) = consistent high COP
+
+    Inherits flow-temperature and power-validation behavior from the S1155
+    sibling profile (same hydraulic family); only identity, sizing, and the
+    slightly lower COP curve differ. Baseline: mid-range 4-12 kW variant.
+    """
+
+    model_name: str = "F1155"
+    model_type: str = "F-series GSHP"
+
+    # Mid-range variant (4-12 kW)
+    rated_power_kw: tuple[float, float] = (4.0, 12.0)  # Heat output
+    typical_electrical_range_kw: tuple[float, float] = (0.6, 2.8)  # Estimated from SCOP ~5.0
+    modulation_range: tuple[int, int] = (20, 120)
+
+    typical_cop_range: tuple[float, float] = (3.3, 5.3)  # GSHP, slightly below S1155
+
+    def __post_init__(self):
+        """Initialize COP curve - S1155 shape shifted slightly down for the
+        older F-series inverter platform."""
+        self.cop_curve = {
+            7: 5.3,
+            5: 5.1,
+            0: 4.8,
+            -5: 4.6,  # Ground temp stable
+            -10: 4.3,  # Ground temp stable
+            -15: 4.1,
+            -20: 3.8,
+            -25: 3.6,
+            -30: 3.3,  # Much better than ASHP at extreme temps
+        }

--- a/custom_components/effektguard/models/types.py
+++ b/custom_components/effektguard/models/types.py
@@ -26,6 +26,13 @@ class EffektGuardConfigDict(TypedDict, total=False):
     additional_indoor_sensors: list[str]
     indoor_temp_method: str
 
+    # Manual sensor overrides (issue #18: Modbus/renamed entities)
+    outdoor_temp_entity: str
+    indoor_temp_entity: str
+    supply_temp_entity: str
+    return_temp_entity: str
+    dhw_charging_temp_entity: str
+
     # Feature flags
     enable_price_optimization: bool
     enable_peak_protection: bool
@@ -71,3 +78,11 @@ class AdapterConfigDict(TypedDict, total=False):
     power_sensor_entity: str
     additional_indoor_sensors: list[str]
     indoor_temp_method: str
+
+    # Manual sensor overrides (issue #18: Modbus/renamed entities)
+    outdoor_temp_entity: str
+    indoor_temp_entity: str
+    supply_temp_entity: str
+    return_temp_entity: str
+    dhw_temp_entity: str
+    dhw_charging_temp_entity: str

--- a/custom_components/effektguard/optimization/decision_engine.py
+++ b/custom_components/effektguard/optimization/decision_engine.py
@@ -107,6 +107,7 @@ class OptimizationDecision:
     layers: list[LayerDecision] = field(default_factory=list)
     reasoning: str = ""
     anti_windup_active: bool = False  # True when anti-windup is driving the decision
+    is_manual_override: bool = False  # True for user-commanded offsets (force_offset/boost)
 
 
 def get_safe_default_decision() -> OptimizationDecision:
@@ -428,6 +429,7 @@ class DecisionEngine:
                     )
                 ],
                 reasoning=f"Manual override active: {manual_override:.1f}°C",
+                is_manual_override=True,
             )
 
         # Update price analyzer with latest data

--- a/custom_components/effektguard/strings.json
+++ b/custom_components/effektguard/strings.json
@@ -3,12 +3,12 @@
     "step": {
       "user": {
         "title": "Configure NIBE Integration",
-        "description": "Select your NIBE heating curve offset entity (number.* with 'offset' in name). Found {nibe_count} compatible entities.\n\n**Your entity:** `number.f750_cu_3x400v_offset`",
+        "description": "Select the number entity that controls your heating curve offset.\n\n{info}\n\nWorks with MyUplink (cloud), nibe_heatpump (local Modbus/NibeGW), or a template number wrapping modbus.write_register.",
         "data": {
           "nibe_entity": "NIBE Heating Curve Offset Entity"
         },
         "data_description": {
-          "nibe_entity": "The NIBE entity that controls the heating curve offset (typically number.*_offset)"
+          "nibe_entity": "The writable number entity for the heating curve offset (register 47011 on F-series, e.g. number.heat_offset_s1_47011, or a MyUplink number ending in heating_offset_climate_system_1)"
         }
       },
       "gespot": {
@@ -19,12 +19,61 @@
           "enable_price_optimization": "Enable price optimization"
         }
       },
+      "model": {
+        "title": "Heat Pump Model",
+        "description": "Select your heat pump model. The model sets safe degree-minute thresholds, COP curves, and flow temperature limits.",
+        "data": {
+          "heat_pump_model": "Heat pump model"
+        }
+      },
       "optional": {
         "title": "Optional Features",
         "description": "Configure optional features. Found {weather_count} weather entities.",
         "data": {
           "weather_entity": "Weather Entity",
           "enable_peak_protection": "Enable peak protection"
+        }
+      },
+      "optional_sensors": {
+        "title": "Sensors",
+        "description": "Optional sensors and manual overrides. Leave a field empty to use automatic discovery.\n\n{dm_note}\n\nThe override fields at the bottom are for setups where discovery cannot find your sensors (generic Modbus, renamed entities).",
+        "data": {
+          "degree_minutes_entity": "Degree minutes entity",
+          "power_sensor_entity": "Power meter sensor",
+          "nibe_temp_lux_entity": "Temporary lux switch (DHW)",
+          "additional_indoor_sensors": "Additional indoor temperature sensors",
+          "indoor_temp_method": "Indoor temperature calculation method",
+          "outdoor_temp_entity": "Override: outdoor temperature (BT1)",
+          "indoor_temp_entity": "Override: indoor temperature (BT50/room sensor)",
+          "supply_temp_entity": "Override: supply temperature (BT2/BT25)",
+          "return_temp_entity": "Override: return temperature (BT3)",
+          "dhw_temp_entity": "Override: hot water top temperature (BT7)",
+          "dhw_charging_temp_entity": "Override: hot water charging temperature (BT6)"
+        },
+        "data_description": {
+          "degree_minutes_entity": "Number entity on nibe_heatpump/MyUplink (register 43005/40940), sensor on generic Modbus. Estimated from the thermal model if not set.",
+          "power_sensor_entity": "Enables accurate peak tracking (estimated from heat pump data if not provided)",
+          "nibe_temp_lux_entity": "Enables intelligent DHW scheduling and thermal debt protection",
+          "additional_indoor_sensors": "Extra room sensors for whole-house averaging. Median is recommended (robust to outliers)."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure EffektGuard",
+        "description": "Change entity selections. Fields left empty are cleared (back to auto-discovery); the offset entity and heat pump model keep their previous values when left empty. The integration reloads automatically.",
+        "data": {
+          "nibe_entity": "NIBE Heating Curve Offset Entity",
+          "heat_pump_model": "Heat pump model",
+          "weather_entity": "Weather Entity",
+          "degree_minutes_entity": "Degree minutes entity",
+          "power_sensor_entity": "Power meter sensor",
+          "nibe_temp_lux_entity": "Temporary lux switch (DHW)",
+          "additional_indoor_sensors": "Additional indoor temperature sensors",
+          "outdoor_temp_entity": "Override: outdoor temperature (BT1)",
+          "indoor_temp_entity": "Override: indoor temperature (BT50/room sensor)",
+          "supply_temp_entity": "Override: supply temperature (BT2/BT25)",
+          "return_temp_entity": "Override: return temperature (BT3)",
+          "dhw_temp_entity": "Override: hot water top temperature (BT7)",
+          "dhw_charging_temp_entity": "Override: hot water charging temperature (BT6)"
         }
       }
     },
@@ -33,7 +82,8 @@
       "gespot_entity_not_found": "Spot price entity not found"
     },
     "abort": {
-      "nibe_not_found": "NIBE integration not found. Please install NIBE Myuplink integration first."
+      "nibe_not_found": "No NIBE integration found. Install and configure MyUplink (cloud) or nibe_heatpump (local Modbus/NibeGW) first.",
+      "reconfigure_successful": "Reconfiguration successful"
     }
   },
   "options": {
@@ -132,4 +182,3 @@
     }
   }
 }
-

--- a/custom_components/effektguard/translations/da.json
+++ b/custom_components/effektguard/translations/da.json
@@ -3,12 +3,12 @@
     "step": {
       "user": {
         "title": "Konfigurer NIBE-integration",
-        "description": "Vælg din NIBE varmekurvejusteringsenhed. Leder efter enheder som 'number.*_offset'. Fandt {nibe_count} kompatible enheder.",
+        "description": "Vælg number-entiteten der styrer din varmekurves forskydning.\n\n{info}\n\nVirker med MyUplink (sky), nibe_heatpump (lokal Modbus/NibeGW) eller et template-number omkring modbus.write_register.",
         "data": {
           "nibe_entity": "NIBE Varmekurvejusteringsenhed"
         },
         "data_description": {
-          "nibe_entity": "NIBE-enheden der styrer varmekurvejustering (typisk number.*_offset)"
+          "nibe_entity": "Skrivbar number-entitet til varmekurvens forskydning (register 47011 på F-serien, f.eks. number.heat_offset_s1_47011)"
         }
       },
       "gespot": {
@@ -26,6 +26,55 @@
           "weather_entity": "Vejrenhed",
           "enable_peak_protection": "Aktiver effektbeskyttelse"
         }
+      },
+      "model": {
+        "title": "Varmepumpemodel",
+        "description": "Vælg din varmepumpemodel. Modellen styrer sikre gradminut-grænser, COP-kurver og fremløbsgrænser.",
+        "data": {
+          "heat_pump_model": "Varmepumpemodel"
+        }
+      },
+      "optional_sensors": {
+        "title": "Sensorer",
+        "description": "Valgfrie sensorer og manuelle tilsidesættelser. Lad et felt stå tomt for automatisk registrering.\n\n{dm_note}\n\nTilsidesættelsesfelterne nederst er til opsætninger hvor registreringen ikke finder dine sensorer (generisk Modbus, omdøbte entiteter).",
+        "data": {
+          "degree_minutes_entity": "Gradminut-entitet",
+          "power_sensor_entity": "Effektmålersensor",
+          "nibe_temp_lux_entity": "Midlertidig luksus-kontakt (varmt vand)",
+          "additional_indoor_sensors": "Ekstra indendørs temperatursensorer",
+          "indoor_temp_method": "Beregningsmetode for indendørstemperatur",
+          "outdoor_temp_entity": "Tilsidesæt: udendørstemperatur (BT1)",
+          "indoor_temp_entity": "Tilsidesæt: indendørstemperatur (BT50/rumsensor)",
+          "supply_temp_entity": "Tilsidesæt: fremløbstemperatur (BT2/BT25)",
+          "return_temp_entity": "Tilsidesæt: returtemperatur (BT3)",
+          "dhw_temp_entity": "Tilsidesæt: varmt vand top (BT7)",
+          "dhw_charging_temp_entity": "Tilsidesæt: varmt vand opladning (BT6)"
+        },
+        "data_description": {
+          "degree_minutes_entity": "Number-entitet i nibe_heatpump/MyUplink (register 43005/40940), sensor i generisk Modbus. Estimeres fra termisk model hvis den ikke angives.",
+          "power_sensor_entity": "Giver præcis spidsbelastningsmåling (estimeres fra varmepumpedata hvis den ikke angives)",
+          "nibe_temp_lux_entity": "Muliggør intelligent varmtvandsplanlægning og beskyttelse mod termisk gæld",
+          "additional_indoor_sensors": "Ekstra rumsensorer til gennemsnit for hele huset. Median anbefales (robust mod outliers)."
+        }
+      },
+      "reconfigure": {
+        "title": "Omkonfigurer EffektGuard",
+        "description": "Ændr entitetsvalg. Tomme felter ryddes (tilbage til automatisk registrering); forskydningsentiteten og varmepumpemodellen beholder deres tidligere værdier hvis de står tomme. Integrationen genindlæses automatisk.",
+        "data": {
+          "nibe_entity": "NIBE-entitet for varmekurvens forskydning",
+          "heat_pump_model": "Varmepumpemodel",
+          "weather_entity": "Vejr-entitet",
+          "degree_minutes_entity": "Gradminut-entitet",
+          "power_sensor_entity": "Effektmålersensor",
+          "nibe_temp_lux_entity": "Midlertidig luksus-kontakt (varmt vand)",
+          "additional_indoor_sensors": "Ekstra indendørs temperatursensorer",
+          "outdoor_temp_entity": "Tilsidesæt: udendørstemperatur (BT1)",
+          "indoor_temp_entity": "Tilsidesæt: indendørstemperatur (BT50/rumsensor)",
+          "supply_temp_entity": "Tilsidesæt: fremløbstemperatur (BT2/BT25)",
+          "return_temp_entity": "Tilsidesæt: returtemperatur (BT3)",
+          "dhw_temp_entity": "Tilsidesæt: varmt vand top (BT7)",
+          "dhw_charging_temp_entity": "Tilsidesæt: varmt vand opladning (BT6)"
+        }
       }
     },
     "error": {
@@ -33,7 +82,8 @@
       "gespot_entity_not_found": "Spotpris-enhed ikke fundet"
     },
     "abort": {
-      "nibe_not_found": "NIBE-integration ikke fundet. Installer venligst NIBE Myuplink-integration først."
+      "nibe_not_found": "Ingen NIBE-integration fundet. Installer og konfigurer MyUplink (sky) eller nibe_heatpump (lokal Modbus/NibeGW) først.",
+      "reconfigure_successful": "Omkonfigurering gennemført"
     }
   },
   "options": {

--- a/custom_components/effektguard/translations/en.json
+++ b/custom_components/effektguard/translations/en.json
@@ -3,12 +3,12 @@
     "step": {
       "user": {
         "title": "Configure NIBE Integration",
-        "description": "Select your NIBE heating curve offset entity. Looking for entities like 'number.*_offset'. Found {nibe_count} compatible entities.",
+        "description": "Select the number entity that controls your heating curve offset.\n\n{info}\n\nWorks with MyUplink (cloud), nibe_heatpump (local Modbus/NibeGW), or a template number wrapping modbus.write_register.",
         "data": {
           "nibe_entity": "NIBE Heating Curve Offset Entity"
         },
         "data_description": {
-          "nibe_entity": "The NIBE entity that controls the heating curve offset (typically number.*_offset)"
+          "nibe_entity": "The writable number entity for the heating curve offset (register 47011 on F-series, e.g. number.heat_offset_s1_47011, or a MyUplink number ending in heating_offset_climate_system_1)"
         }
       },
       "gespot": {
@@ -19,12 +19,61 @@
           "enable_price_optimization": "Enable price optimization"
         }
       },
+      "model": {
+        "title": "Heat Pump Model",
+        "description": "Select your heat pump model. The model sets safe degree-minute thresholds, COP curves, and flow temperature limits.",
+        "data": {
+          "heat_pump_model": "Heat pump model"
+        }
+      },
       "optional": {
         "title": "Optional Features",
         "description": "Configure optional features. Found {weather_count} weather entities.",
         "data": {
           "weather_entity": "Weather Entity",
           "enable_peak_protection": "Enable peak protection"
+        }
+      },
+      "optional_sensors": {
+        "title": "Sensors",
+        "description": "Optional sensors and manual overrides. Leave a field empty to use automatic discovery.\n\n{dm_note}\n\nThe override fields at the bottom are for setups where discovery cannot find your sensors (generic Modbus, renamed entities).",
+        "data": {
+          "degree_minutes_entity": "Degree minutes entity",
+          "power_sensor_entity": "Power meter sensor",
+          "nibe_temp_lux_entity": "Temporary lux switch (DHW)",
+          "additional_indoor_sensors": "Additional indoor temperature sensors",
+          "indoor_temp_method": "Indoor temperature calculation method",
+          "outdoor_temp_entity": "Override: outdoor temperature (BT1)",
+          "indoor_temp_entity": "Override: indoor temperature (BT50/room sensor)",
+          "supply_temp_entity": "Override: supply temperature (BT2/BT25)",
+          "return_temp_entity": "Override: return temperature (BT3)",
+          "dhw_temp_entity": "Override: hot water top temperature (BT7)",
+          "dhw_charging_temp_entity": "Override: hot water charging temperature (BT6)"
+        },
+        "data_description": {
+          "degree_minutes_entity": "Number entity on nibe_heatpump/MyUplink (register 43005/40940), sensor on generic Modbus. Estimated from the thermal model if not set.",
+          "power_sensor_entity": "Enables accurate peak tracking (estimated from heat pump data if not provided)",
+          "nibe_temp_lux_entity": "Enables intelligent DHW scheduling and thermal debt protection",
+          "additional_indoor_sensors": "Extra room sensors for whole-house averaging. Median is recommended (robust to outliers)."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure EffektGuard",
+        "description": "Change entity selections. Fields left empty are cleared (back to auto-discovery); the offset entity and heat pump model keep their previous values when left empty. The integration reloads automatically.",
+        "data": {
+          "nibe_entity": "NIBE Heating Curve Offset Entity",
+          "heat_pump_model": "Heat pump model",
+          "weather_entity": "Weather Entity",
+          "degree_minutes_entity": "Degree minutes entity",
+          "power_sensor_entity": "Power meter sensor",
+          "nibe_temp_lux_entity": "Temporary lux switch (DHW)",
+          "additional_indoor_sensors": "Additional indoor temperature sensors",
+          "outdoor_temp_entity": "Override: outdoor temperature (BT1)",
+          "indoor_temp_entity": "Override: indoor temperature (BT50/room sensor)",
+          "supply_temp_entity": "Override: supply temperature (BT2/BT25)",
+          "return_temp_entity": "Override: return temperature (BT3)",
+          "dhw_temp_entity": "Override: hot water top temperature (BT7)",
+          "dhw_charging_temp_entity": "Override: hot water charging temperature (BT6)"
         }
       }
     },
@@ -33,7 +82,8 @@
       "gespot_entity_not_found": "Spot price entity not found"
     },
     "abort": {
-      "nibe_not_found": "NIBE integration not found. Please install NIBE Myuplink integration first."
+      "nibe_not_found": "No NIBE integration found. Install and configure MyUplink (cloud) or nibe_heatpump (local Modbus/NibeGW) first.",
+      "reconfigure_successful": "Reconfiguration successful"
     }
   },
   "options": {

--- a/custom_components/effektguard/translations/fi.json
+++ b/custom_components/effektguard/translations/fi.json
@@ -3,12 +3,12 @@
     "step": {
       "user": {
         "title": "Määritä NIBE-integraatio",
-        "description": "Valitse NIBE lämmityskäyrän säätöyksikkö. Etsitään yksiköitä kuten 'number.*_offset'. Löytyi {nibe_count} yhteensopivaa yksikköä.",
+        "description": "Valitse number-entiteetti joka ohjaa lämpökäyrän siirtymää.\n\n{info}\n\nToimii MyUplinkin (pilvi), nibe_heatpumpin (paikallinen Modbus/NibeGW) tai modbus.write_register-palvelua käyttävän template-numberin kanssa.",
         "data": {
           "nibe_entity": "NIBE Lämmityskäyrän säätöyksikkö"
         },
         "data_description": {
-          "nibe_entity": "NIBE-yksikkö joka ohjaa lämmityskäyrän säätöä (tyypillisesti number.*_offset)"
+          "nibe_entity": "Kirjoitettava number-entiteetti lämpökäyrän siirtymälle (rekisteri 47011 F-sarjassa, esim. number.heat_offset_s1_47011)"
         }
       },
       "gespot": {
@@ -26,6 +26,55 @@
           "weather_entity": "Sääyksikkö",
           "enable_peak_protection": "Ota käyttöön tehon suojaus"
         }
+      },
+      "model": {
+        "title": "Lämpöpumpun malli",
+        "description": "Valitse lämpöpumppusi malli. Malli määrittää turvalliset asteminuuttirajat, COP-käyrät ja menoveden rajat.",
+        "data": {
+          "heat_pump_model": "Lämpöpumpun malli"
+        }
+      },
+      "optional_sensors": {
+        "title": "Anturit",
+        "description": "Valinnaiset anturit ja manuaaliset ohitukset. Jätä kenttä tyhjäksi automaattista tunnistusta varten.\n\n{dm_note}\n\nAlimmat ohituskentät ovat kokoonpanoille joissa tunnistus ei löydä antureitasi (yleinen Modbus, uudelleennimetyt entiteetit).",
+        "data": {
+          "degree_minutes_entity": "Asteminuutti-entiteetti",
+          "power_sensor_entity": "Tehomittarianturi",
+          "nibe_temp_lux_entity": "Tilapäinen luksus-kytkin (lämmin vesi)",
+          "additional_indoor_sensors": "Lisäsisälämpötila-anturit",
+          "indoor_temp_method": "Sisälämpötilan laskentatapa",
+          "outdoor_temp_entity": "Ohita: ulkolämpötila (BT1)",
+          "indoor_temp_entity": "Ohita: sisälämpötila (BT50/huoneanturi)",
+          "supply_temp_entity": "Ohita: menoveden lämpötila (BT2/BT25)",
+          "return_temp_entity": "Ohita: paluuveden lämpötila (BT3)",
+          "dhw_temp_entity": "Ohita: lämmin vesi yläosa (BT7)",
+          "dhw_charging_temp_entity": "Ohita: lämmin vesi lataus (BT6)"
+        },
+        "data_description": {
+          "degree_minutes_entity": "Number-entiteetti nibe_heatpumpissa/MyUplinkissä (rekisteri 43005/40940), sensor yleisessä Modbusissa. Arvioidaan lämpömallista jos ei asetettu.",
+          "power_sensor_entity": "Mahdollistaa tarkan huipputehon seurannan (arvioidaan lämpöpumpun tiedoista jos ei asetettu)",
+          "nibe_temp_lux_entity": "Mahdollistaa älykkään käyttöveden aikataulutuksen ja lämpövelkasuojan",
+          "additional_indoor_sensors": "Lisähuoneanturit koko talon keskiarvoa varten. Mediaani suositeltu (kestää poikkeamat)."
+        }
+      },
+      "reconfigure": {
+        "title": "Määritä EffektGuard uudelleen",
+        "description": "Muuta entiteettivalintoja. Tyhjät kentät tyhjennetään (takaisin automaattiseen tunnistukseen); siirtymäentiteetti ja lämpöpumpun malli säilyttävät aiemmat arvonsa jos ne jätetään tyhjiksi. Integraatio latautuu uudelleen automaattisesti.",
+        "data": {
+          "nibe_entity": "NIBE-lämpökäyrän siirtymäentiteetti",
+          "heat_pump_model": "Lämpöpumpun malli",
+          "weather_entity": "Sää-entiteetti",
+          "degree_minutes_entity": "Asteminuutti-entiteetti",
+          "power_sensor_entity": "Tehomittarianturi",
+          "nibe_temp_lux_entity": "Tilapäinen luksus-kytkin (lämmin vesi)",
+          "additional_indoor_sensors": "Lisäsisälämpötila-anturit",
+          "outdoor_temp_entity": "Ohita: ulkolämpötila (BT1)",
+          "indoor_temp_entity": "Ohita: sisälämpötila (BT50/huoneanturi)",
+          "supply_temp_entity": "Ohita: menoveden lämpötila (BT2/BT25)",
+          "return_temp_entity": "Ohita: paluuveden lämpötila (BT3)",
+          "dhw_temp_entity": "Ohita: lämmin vesi yläosa (BT7)",
+          "dhw_charging_temp_entity": "Ohita: lämmin vesi lataus (BT6)"
+        }
       }
     },
     "error": {
@@ -33,7 +82,8 @@
       "gespot_entity_not_found": "Spot-hinta-yksikköä ei löytynyt"
     },
     "abort": {
-      "nibe_not_found": "NIBE-integraatiota ei löytynyt. Asenna ensin NIBE Myuplink-integraatio."
+      "nibe_not_found": "NIBE-integraatiota ei löytynyt. Asenna ja määritä ensin MyUplink (pilvi) tai nibe_heatpump (paikallinen Modbus/NibeGW).",
+      "reconfigure_successful": "Uudelleenmääritys onnistui"
     }
   },
   "options": {

--- a/custom_components/effektguard/translations/no.json
+++ b/custom_components/effektguard/translations/no.json
@@ -3,12 +3,12 @@
     "step": {
       "user": {
         "title": "Konfigurer NIBE-integrasjon",
-        "description": "Velg din NIBE varmekurvejusteringsenhet. Leter etter enheter som 'number.*_offset'. Fant {nibe_count} kompatible enheter.",
+        "description": "Velg number-entiteten som styrer varmekurvens forskyvning.\n\n{info}\n\nFungerer med MyUplink (sky), nibe_heatpump (lokal Modbus/NibeGW) eller et template-number rundt modbus.write_register.",
         "data": {
           "nibe_entity": "NIBE Varmekurvejusteringsenhet"
         },
         "data_description": {
-          "nibe_entity": "NIBE-enheten som kontrollerer varmekurvejustering (vanligvis number.*_offset)"
+          "nibe_entity": "Skrivbar number-entitet for varmekurvens forskyvning (register 47011 på F-serien, f.eks. number.heat_offset_s1_47011)"
         }
       },
       "gespot": {
@@ -26,6 +26,55 @@
           "weather_entity": "Værenhet",
           "enable_peak_protection": "Aktiver effektbeskyttelse"
         }
+      },
+      "model": {
+        "title": "Varmepumpemodell",
+        "description": "Velg varmepumpemodellen din. Modellen styrer trygge gradminutt-terskler, COP-kurver og turtemperaturgrenser.",
+        "data": {
+          "heat_pump_model": "Varmepumpemodell"
+        }
+      },
+      "optional_sensors": {
+        "title": "Sensorer",
+        "description": "Valgfrie sensorer og manuelle overstyringer. La et felt stå tomt for automatisk oppdaging.\n\n{dm_note}\n\nOverstyringsfeltene nederst er for oppsett der oppdagingen ikke finner sensorene dine (generisk Modbus, omdøpte entiteter).",
+        "data": {
+          "degree_minutes_entity": "Gradminutt-entitet",
+          "power_sensor_entity": "Effektmålersensor",
+          "nibe_temp_lux_entity": "Midlertidig luksus-bryter (varmtvann)",
+          "additional_indoor_sensors": "Ekstra innendørs temperatursensorer",
+          "indoor_temp_method": "Beregningsmetode for innetemperatur",
+          "outdoor_temp_entity": "Overstyr: utetemperatur (BT1)",
+          "indoor_temp_entity": "Overstyr: innetemperatur (BT50/romsensor)",
+          "supply_temp_entity": "Overstyr: turtemperatur (BT2/BT25)",
+          "return_temp_entity": "Overstyr: returtemperatur (BT3)",
+          "dhw_temp_entity": "Overstyr: varmtvann topp (BT7)",
+          "dhw_charging_temp_entity": "Overstyr: varmtvann lading (BT6)"
+        },
+        "data_description": {
+          "degree_minutes_entity": "Number-entitet i nibe_heatpump/MyUplink (register 43005/40940), sensor i generisk Modbus. Estimeres fra termisk modell hvis ikke angitt.",
+          "power_sensor_entity": "Gir nøyaktig toppmåling (estimeres fra varmepumpedata hvis ikke angitt)",
+          "nibe_temp_lux_entity": "Muliggjør intelligent varmtvannsplanlegging og beskyttelse mot termisk gjeld",
+          "additional_indoor_sensors": "Ekstra romsensorer for gjennomsnitt i hele huset. Median anbefales (robust mot avvik)."
+        }
+      },
+      "reconfigure": {
+        "title": "Omkonfigurer EffektGuard",
+        "description": "Endre entitetsvalg. Tomme felt tømmes (tilbake til automatisk oppdaging); forskyvningsentiteten og varmepumpemodellen beholder tidligere verdier hvis de står tomme. Integrasjonen lastes inn på nytt automatisk.",
+        "data": {
+          "nibe_entity": "NIBE-entitet for varmekurvens forskyvning",
+          "heat_pump_model": "Varmepumpemodell",
+          "weather_entity": "Vær-entitet",
+          "degree_minutes_entity": "Gradminutt-entitet",
+          "power_sensor_entity": "Effektmålersensor",
+          "nibe_temp_lux_entity": "Midlertidig luksus-bryter (varmtvann)",
+          "additional_indoor_sensors": "Ekstra innendørs temperatursensorer",
+          "outdoor_temp_entity": "Overstyr: utetemperatur (BT1)",
+          "indoor_temp_entity": "Overstyr: innetemperatur (BT50/romsensor)",
+          "supply_temp_entity": "Overstyr: turtemperatur (BT2/BT25)",
+          "return_temp_entity": "Overstyr: returtemperatur (BT3)",
+          "dhw_temp_entity": "Overstyr: varmtvann topp (BT7)",
+          "dhw_charging_temp_entity": "Overstyr: varmtvann lading (BT6)"
+        }
       }
     },
     "error": {
@@ -33,7 +82,8 @@
       "gespot_entity_not_found": "Spotpris-enhet ikke funnet"
     },
     "abort": {
-      "nibe_not_found": "NIBE-integrasjon ikke funnet. Vennligst installer NIBE Myuplink-integrasjon først."
+      "nibe_not_found": "Ingen NIBE-integrasjon funnet. Installer og konfigurer MyUplink (sky) eller nibe_heatpump (lokal Modbus/NibeGW) først.",
+      "reconfigure_successful": "Omkonfigurering fullført"
     }
   },
   "options": {

--- a/custom_components/effektguard/translations/sv.json
+++ b/custom_components/effektguard/translations/sv.json
@@ -1,134 +1,189 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "title": "Konfigurera NIBE-integration",
-                "description": "Välj din NIBE-värmepump. Hittade {nibe_count} NIBE-enheter.",
-                "data": {"nibe_entity": "NIBE-enhet"}
-            },
-            "gespot": {
-                "title": "Konfigurera spotpris-integration",
-                "description": "Konfigurera valfritt spotpris för 15-minuters prisoptimering.\n\n{detection_info}\n\n**Rekommenderat:** Använd `current_price`-sensor för prisoptimering i realtid per kvart.",
-                "data": {
-                    "gespot_entity": "Spotpris-sensor (Current Price Rekommenderas)",
-                    "enable_price_optimization": "Aktivera prisoptimering"
-                }
-            },
-            "optional": {
-                "title": "Valfria funktioner",
-                "description": "Konfigurera valfria funktioner. Hittade {weather_count} väderenheter.",
-                "data": {
-                    "weather_entity": "Väderenhet",
-                    "enable_peak_protection": "Aktivera effektskydd"
-                }
-            }
+  "config": {
+    "step": {
+      "user": {
+        "title": "Konfigurera NIBE-integration",
+        "description": "Välj number-entiteten som styr din värmekurvas förskjutning.\n\n{info}\n\nFungerar med MyUplink (moln), nibe_heatpump (lokal Modbus/NibeGW) eller ett template-number som omsluter modbus.write_register.",
+        "data": {
+          "nibe_entity": "NIBE-enhet"
         },
-        "error": {
-            "nibe_entity_not_found": "NIBE-enhet hittades inte",
-            "gespot_entity_not_found": "Spotpris-enhet hittades inte"
+        "data_description": {
+          "nibe_entity": "Skrivbar number-entitet för värmekurvans förskjutning (register 47011 på F-serien, t.ex. number.heat_offset_s1_47011, eller ett MyUplink-number som slutar på heating_offset_climate_system_1)"
+        }
+      },
+      "gespot": {
+        "title": "Konfigurera spotpris-integration",
+        "description": "Konfigurera valfritt spotpris för 15-minuters prisoptimering.\n\n{detection_info}\n\n**Rekommenderat:** Använd `current_price`-sensor för prisoptimering i realtid per kvart.",
+        "data": {
+          "gespot_entity": "Spotpris-sensor (Current Price Rekommenderas)",
+          "enable_price_optimization": "Aktivera prisoptimering"
+        }
+      },
+      "optional": {
+        "title": "Valfria funktioner",
+        "description": "Konfigurera valfria funktioner. Hittade {weather_count} väderenheter.",
+        "data": {
+          "weather_entity": "Väderenhet",
+          "enable_peak_protection": "Aktivera effektskydd"
+        }
+      },
+      "model": {
+        "title": "Värmepumpsmodell",
+        "description": "Välj din värmepumpsmodell. Modellen styr säkra gradminutströsklar, COP-kurvor och framledningsgränser.",
+        "data": {
+          "heat_pump_model": "Värmepumpsmodell"
+        }
+      },
+      "optional_sensors": {
+        "title": "Sensorer",
+        "description": "Valfria sensorer och manuella åsidosättningar. Lämna ett fält tomt för automatisk identifiering.\n\n{dm_note}\n\nÅsidosättningsfälten längst ner är till för installationer där identifieringen inte hittar dina sensorer (generisk Modbus, omdöpta entiteter).",
+        "data": {
+          "degree_minutes_entity": "Gradminuter-entitet",
+          "power_sensor_entity": "Effektmätarsensor",
+          "nibe_temp_lux_entity": "Tillfällig lyx-brytare (varmvatten)",
+          "additional_indoor_sensors": "Extra inomhustemperatursensorer",
+          "indoor_temp_method": "Beräkningsmetod för inomhustemperatur",
+          "outdoor_temp_entity": "Åsidosätt: utomhustemperatur (BT1)",
+          "indoor_temp_entity": "Åsidosätt: inomhustemperatur (BT50/rumssensor)",
+          "supply_temp_entity": "Åsidosätt: framledningstemperatur (BT2/BT25)",
+          "return_temp_entity": "Åsidosätt: returtemperatur (BT3)",
+          "dhw_temp_entity": "Åsidosätt: varmvatten topp (BT7)",
+          "dhw_charging_temp_entity": "Åsidosätt: varmvatten laddning (BT6)"
         },
-        "abort": {
-            "nibe_not_found": "NIBE-integration hittades inte. Installera NIBE Myuplink-integration först."
+        "data_description": {
+          "degree_minutes_entity": "Number-entitet i nibe_heatpump/MyUplink (register 43005/40940), sensor i generisk Modbus. Uppskattas från termisk modell om den inte anges.",
+          "power_sensor_entity": "Ger exakt toppeffektmätning (uppskattas från värmepumpsdata om den inte anges)",
+          "nibe_temp_lux_entity": "Möjliggör intelligent varmvattenschemaläggning och skydd mot termisk skuld",
+          "additional_indoor_sensors": "Extra rumssensorer för medelvärde i hela huset. Median rekommenderas (robust mot avvikare)."
         }
+      },
+      "reconfigure": {
+        "title": "Omkonfigurera EffektGuard",
+        "description": "Ändra entitetsval. Tomma fält rensas (åter till automatisk identifiering); förskjutningsentiteten och värmepumpsmodellen behåller sina tidigare värden om de lämnas tomma. Integrationen laddas om automatiskt.",
+        "data": {
+          "nibe_entity": "NIBE-entitet för värmekurvans förskjutning",
+          "heat_pump_model": "Värmepumpsmodell",
+          "weather_entity": "Väderentitet",
+          "degree_minutes_entity": "Gradminuter-entitet",
+          "power_sensor_entity": "Effektmätarsensor",
+          "nibe_temp_lux_entity": "Tillfällig lyx-brytare (varmvatten)",
+          "additional_indoor_sensors": "Extra inomhustemperatursensorer",
+          "outdoor_temp_entity": "Åsidosätt: utomhustemperatur (BT1)",
+          "indoor_temp_entity": "Åsidosätt: inomhustemperatur (BT50/rumssensor)",
+          "supply_temp_entity": "Åsidosätt: framledningstemperatur (BT2/BT25)",
+          "return_temp_entity": "Åsidosätt: returtemperatur (BT3)",
+          "dhw_temp_entity": "Åsidosätt: varmvatten topp (BT7)",
+          "dhw_charging_temp_entity": "Åsidosätt: varmvatten laddning (BT6)"
+        }
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "EffektGuard-alternativ",
-                "description": "Konfigurera optimeringsbeteende och byggnadsegenskaper.\n\n**Ändringar tillämpas omedelbart** utan omstart. Använd **Omkonfigurera** för att ändra sensorval.",
-                "data": {
-                    "optimization_mode": "Optimeringsläge"
-                },
-                "data_description": {
-                    "optimization_mode": "**Komfort**: Tight temperaturkontroll, minimal prisoptimering, prioriterar stabil värme. **Balanserad**: Måttlig optimering som tillåter små temperaturvariationer för kostnadsbesparingar. **Besparingar**: Maximal prisoptimering med större temperatursvängningar under billiga/dyra perioder"
-                },
-                "sections": {
-                    "comfort_settings": {
-                        "name": "Komfortinställningar",
-                        "description": "Finjustera temperaturkomforttolerans",
-                        "data": {
-                            "tolerance": "Temperaturtolerans"
-                        },
-                        "data_description": {
-                            "tolerance": "Styr tillåten temperaturavvikelse från mål (±0,2°C dödzon bibehålls alltid). Högre värden tillåter mer aggressiv kostnadsoptimering men större temperatursvängningar"
-                        }
-                    },
-                    "dhw_settings": {
-                        "name": "Varmvatteninställningar",
-                        "description": "Schemalägg när varmvatten ska värmas",
-                        "data": {
-                            "dhw_target_temp": "Varmvatten måltemperatur",
-                            "dhw_morning_enabled": "Morgon varmvatten",
-                            "dhw_morning_hour": "Morgon starttid",
-                            "dhw_evening_enabled": "Kväll varmvatten",
-                            "dhw_evening_hour": "Kväll starttid"
-                        },
-                        "data_description": {
-                            "dhw_target_temp": "Måltemperatur för varmvatten (45-60°C)",
-                            "dhw_morning_enabled": "Aktivera uppvärmning av varmvatten på morgonen",
-                            "dhw_morning_hour": "Morgonbehovsperiod starttimme",
-                            "dhw_evening_enabled": "Aktivera uppvärmning av varmvatten på kvällen",
-                            "dhw_evening_hour": "Kvällsbehovsperiod starttimme"
-                        }
-                    },
-                    "building_characteristics": {
-                        "name": "Byggnadsegenskaper",
-                        "description": "Hjälper till att förutsäga ditt hems termiska beteende",
-                        "data": {
-                            "thermal_mass": "Byggnadens termiska massa",
-                            "insulation_quality": "Byggnadens isoleringskvalitet"
-                        },
-                        "data_description": {
-                            "thermal_mass": "Hur snabbt byggnaden reagerar på förändringar (0,5=lätt/trä, 1,0=normal, 2,0=tung/betong)",
-                            "insulation_quality": "Övergripande isoleringsnivå (0,5=dålig, 1,0=normal, 2,0=utmärkt)"
-                        }
-                    },
-                    "airflow_optimization": {
-                        "name": "Luftflödesoptimering (Frånluft)",
-                        "description": "Konfigurera luftflödeshastigheter för frånluftsvärmepumpar. Aktivera/inaktivera via Luftflödesoptimering-knappen i Kontroller.",
-                        "data": {
-                            "airflow_standard_rate": "Standard luftflödeshastighet",
-                            "airflow_enhanced_rate": "Förstärkt luftflödeshastighet"
-                        },
-                        "data_description": {
-                            "airflow_standard_rate": "Normal ventilationshastighet vid daglig drift.\nStäll in efter önskad komfortnivå.\n\nNIBE F750 standard: 150 m³/h (hastighet 2).",
-                            "airflow_enhanced_rate": "Ökad ventilationshastighet vid gynnsamma förhållanden för att utvinna mer värme från frånluften och förbättra COP.\n\nNIBE F750 standard: 252 m³/h (hastighet 4)."
-                        }
-                    }
-                }
-            }
-        }
+    "error": {
+      "nibe_entity_not_found": "NIBE-enhet hittades inte",
+      "gespot_entity_not_found": "Spotpris-enhet hittades inte"
     },
-    "entity": {
-        "switch": {
-            "enable_optimization": {
-                "name": "Aktivera optimering"
-            },
-            "price_optimization": {
-                "name": "Prisoptimering"
-            },
-            "peak_protection": {
-                "name": "Effektskydd"
-            },
-            "weather_prediction": {
-                "name": "Väderprediktion"
-            },
-            "hot_water_optimization": {
-                "name": "Varmvattenoptimering"
-            },
-            "airflow_optimization": {
-                "name": "Luftflödesoptimering"
-            }
-        }
-    },
-    "services": {
-        "boost_heating": {
-            "name": "Boosta uppvärmning",
-            "description": "Öka tillfälligt uppvärmningen för snabb komfort"
-        },
-        "boost_hot_water": {
-            "name": "Boosta varmvatten",
-            "description": "Starta omedelbar varmvattencykel"
-        }
+    "abort": {
+      "nibe_not_found": "Ingen NIBE-integration hittades. Installera och konfigurera MyUplink (moln) eller nibe_heatpump (lokal Modbus/NibeGW) först.",
+      "reconfigure_successful": "Omkonfigurering lyckades"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "EffektGuard-alternativ",
+        "description": "Konfigurera optimeringsbeteende och byggnadsegenskaper.\n\n**Ändringar tillämpas omedelbart** utan omstart. Använd **Omkonfigurera** för att ändra sensorval.",
+        "data": {
+          "optimization_mode": "Optimeringsläge"
+        },
+        "data_description": {
+          "optimization_mode": "**Komfort**: Tight temperaturkontroll, minimal prisoptimering, prioriterar stabil värme. **Balanserad**: Måttlig optimering som tillåter små temperaturvariationer för kostnadsbesparingar. **Besparingar**: Maximal prisoptimering med större temperatursvängningar under billiga/dyra perioder"
+        },
+        "sections": {
+          "comfort_settings": {
+            "name": "Komfortinställningar",
+            "description": "Finjustera temperaturkomforttolerans",
+            "data": {
+              "tolerance": "Temperaturtolerans"
+            },
+            "data_description": {
+              "tolerance": "Styr tillåten temperaturavvikelse från mål (±0,2°C dödzon bibehålls alltid). Högre värden tillåter mer aggressiv kostnadsoptimering men större temperatursvängningar"
+            }
+          },
+          "dhw_settings": {
+            "name": "Varmvatteninställningar",
+            "description": "Schemalägg när varmvatten ska värmas",
+            "data": {
+              "dhw_target_temp": "Varmvatten måltemperatur",
+              "dhw_morning_enabled": "Morgon varmvatten",
+              "dhw_morning_hour": "Morgon starttid",
+              "dhw_evening_enabled": "Kväll varmvatten",
+              "dhw_evening_hour": "Kväll starttid"
+            },
+            "data_description": {
+              "dhw_target_temp": "Måltemperatur för varmvatten (45-60°C)",
+              "dhw_morning_enabled": "Aktivera uppvärmning av varmvatten på morgonen",
+              "dhw_morning_hour": "Morgonbehovsperiod starttimme",
+              "dhw_evening_enabled": "Aktivera uppvärmning av varmvatten på kvällen",
+              "dhw_evening_hour": "Kvällsbehovsperiod starttimme"
+            }
+          },
+          "building_characteristics": {
+            "name": "Byggnadsegenskaper",
+            "description": "Hjälper till att förutsäga ditt hems termiska beteende",
+            "data": {
+              "thermal_mass": "Byggnadens termiska massa",
+              "insulation_quality": "Byggnadens isoleringskvalitet"
+            },
+            "data_description": {
+              "thermal_mass": "Hur snabbt byggnaden reagerar på förändringar (0,5=lätt/trä, 1,0=normal, 2,0=tung/betong)",
+              "insulation_quality": "Övergripande isoleringsnivå (0,5=dålig, 1,0=normal, 2,0=utmärkt)"
+            }
+          },
+          "airflow_optimization": {
+            "name": "Luftflödesoptimering (Frånluft)",
+            "description": "Konfigurera luftflödeshastigheter för frånluftsvärmepumpar. Aktivera/inaktivera via Luftflödesoptimering-knappen i Kontroller.",
+            "data": {
+              "airflow_standard_rate": "Standard luftflödeshastighet",
+              "airflow_enhanced_rate": "Förstärkt luftflödeshastighet"
+            },
+            "data_description": {
+              "airflow_standard_rate": "Normal ventilationshastighet vid daglig drift.\nStäll in efter önskad komfortnivå.\n\nNIBE F750 standard: 150 m³/h (hastighet 2).",
+              "airflow_enhanced_rate": "Ökad ventilationshastighet vid gynnsamma förhållanden för att utvinna mer värme från frånluften och förbättra COP.\n\nNIBE F750 standard: 252 m³/h (hastighet 4)."
+            }
+          }
+        }
+      }
+    }
+  },
+  "entity": {
+    "switch": {
+      "enable_optimization": {
+        "name": "Aktivera optimering"
+      },
+      "price_optimization": {
+        "name": "Prisoptimering"
+      },
+      "peak_protection": {
+        "name": "Effektskydd"
+      },
+      "weather_prediction": {
+        "name": "Väderprediktion"
+      },
+      "hot_water_optimization": {
+        "name": "Varmvattenoptimering"
+      },
+      "airflow_optimization": {
+        "name": "Luftflödesoptimering"
+      }
+    }
+  },
+  "services": {
+    "boost_heating": {
+      "name": "Boosta uppvärmning",
+      "description": "Öka tillfälligt uppvärmningen för snabb komfort"
+    },
+    "boost_hot_water": {
+      "name": "Boosta varmvatten",
+      "description": "Starta omedelbar varmvattencykel"
+    }
+  }
 }

--- a/docs/architecture/01_normal_optimization_cycle.md
+++ b/docs/architecture/01_normal_optimization_cycle.md
@@ -117,7 +117,8 @@ The decision engine processes data through 7 prioritized layers:
 ### 3. Decision Aggregation
 - Critical layers (weight 1.0) override all others
 - Non-critical layers use weighted averaging
-- Final offset applied via NIBE MyUplink entity
+- Final offset applied via the NIBE offset number entity
+  (MyUplink, nibe_heatpump, or a template number wrapping modbus.write_register)
 
 ### 4. State Updates
 All entities are updated with:

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -68,7 +68,7 @@ custom_components/effektguard/
 │   └── climate_zones.py     # Climate-aware thresholds
 │
 ├── adapters/                # External data interfaces
-│   ├── nibe_adapter.py      # NIBE MyUplink reader
+│   ├── nibe_adapter.py      # NIBE entity reader (MyUplink / nibe_heatpump / Modbus)
 │   ├── gespot_adapter.py    # Spot Price price reader
 │   └── weather_adapter.py   # Weather forecast reader
 │
@@ -161,8 +161,8 @@ grep "NIBE state:" logs/effektguard.log
 ## Research Documentation
 
 NIBE-specific behavior is based on research:
-- `IMPLEMENTATION_PLAN/02_Research/Forum_Summary.md` - F2040 real-world cases
-- `IMPLEMENTATION_PLAN/02_Research/Swedish_NIBE_Forum_Findings.md` - F750 optimization
+- NIBE research references live in code docstrings and const.py comments
+  (F2040 forum cases, Swedish F750 findings)
 - `docs/CLIMATE_ZONES.md` - Climate-aware safety system
 
 **Never guess NIBE behavior** - always reference research!
@@ -205,9 +205,8 @@ Before submitting PR:
 - `../../architecture/10_adaptive_climate_zones.md` - Climate adaptation
 
 ### Research Documentation
-- `../../IMPLEMENTATION_PLAN/02_Research/` - NIBE research findings
-- `../../IMPLEMENTATION_PLAN/01_Algorithm/` - Algorithm specifications
-- `../../IMPLEMENTATION_PLAN/03_API/` - MyUplink API guide
+- NIBE research references are inline in code docstrings and const.py comments
+  (the historical IMPLEMENTATION_PLAN/ folder is not part of this repository)
 
 ---
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "EffektGuard",
   "render_readme": true,
-  "homeassistant": "2024.1.0"
+  "homeassistant": "2025.10.0"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,28 @@ def setup_frame_helper(monkeypatch):
 
 
 # Common mock helper functions
+def make_mock_async_all(states_by_id: dict):
+    """Build a hass.states.async_all replacement honoring HA's domain filter.
+
+    Args:
+        states_by_id: Mapping of entity_id -> mock state object
+
+    Returns:
+        Callable with the same (domain_filter=None) signature as HA's
+        StateMachine.async_all
+    """
+
+    def mock_async_all(domain_filter=None):
+        states = list(states_by_id.values())
+        if domain_filter is None:
+            return states
+        if isinstance(domain_filter, str):
+            domain_filter = (domain_filter,)
+        return [s for s in states if s.entity_id.split(".")[0] in domain_filter]
+
+    return mock_async_all
+
+
 def create_mock_hass(latitude: float = 59.3):
     """Create a properly configured mock Home Assistant instance.
 

--- a/tests/test_config_flow_model_selection.py
+++ b/tests/test_config_flow_model_selection.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from conftest import make_mock_async_all
 from custom_components.effektguard.config_flow import EffektGuardConfigFlow
 from custom_components.effektguard.const import (
     CONF_NIBE_ENTITY,
@@ -98,14 +99,10 @@ def mock_hass(mock_entity_registry, monkeypatch):
         ),
     }
 
-    def mock_async_all():
-        # Return list of state objects, not tuples
-        return list(mock_states.values())
-
     def mock_get_state(entity_id):
         return mock_states.get(entity_id)
 
-    mock_states_obj.async_all = mock_async_all
+    mock_states_obj.async_all = make_mock_async_all(mock_states)
     mock_states_obj.get = mock_get_state
 
     return hass
@@ -130,7 +127,7 @@ class TestConfigFlowUserStep:
         hass = MagicMock(spec=HomeAssistant)
         mock_states_obj = MagicMock()
         hass.states = mock_states_obj
-        mock_states_obj.async_all = lambda: []  # No entities
+        mock_states_obj.async_all = lambda domain_filter=None: []  # No entities
 
         # Patch entity registry
         monkeypatch.setattr(
@@ -147,7 +144,7 @@ class TestConfigFlowUserStep:
         assert result["step_id"] == "user"
         # Check for warning content, not emoji (to avoid Unicode issues)
         assert "No NIBE offset entities auto-detected" in result["description_placeholders"]["info"]
-        assert "MyUplink just loaded" in result["description_placeholders"]["info"]
+        assert "MyUplink, nibe_heatpump, Modbus" in result["description_placeholders"]["info"]
 
     async def test_user_step_valid_submission(self, mock_hass):
         """Test valid NIBE entity submission proceeds to spot price step."""
@@ -613,13 +610,14 @@ class TestModelStepIntegration:
         assert DEFAULT_HEAT_PUMP_MODEL == "nibe_f750"
 
     def test_all_model_keys_match_registry(self):
-        """Test that config flow model keys match coordinator registry."""
-        from custom_components.effektguard.coordinator import HEAT_PUMP_MODELS
+        """Test that config flow model keys resolve in the model registry."""
+        from custom_components.effektguard.models.registry import HeatPumpModelRegistry
 
-        expected_models = ["nibe_f730", "nibe_f750", "nibe_f2040", "nibe_s1155"]
+        expected_models = ["nibe_f730", "nibe_f750", "nibe_f1155", "nibe_f2040", "nibe_s1155"]
 
+        supported = HeatPumpModelRegistry.get_supported_models()
         for model_key in expected_models:
-            assert model_key in HEAT_PUMP_MODELS
+            assert model_key in supported
 
 
 if __name__ == "__main__":

--- a/tests/test_optional_features.py
+++ b/tests/test_optional_features.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 from homeassistant.core import HomeAssistant
 
+from conftest import make_mock_async_all
 from custom_components.effektguard.config_flow import EffektGuardConfigFlow
 from custom_components.effektguard.const import (
     CONF_DEGREE_MINUTES_ENTITY,
@@ -87,14 +88,10 @@ def mock_hass():
         attributes={},
     )
 
-    def mock_async_all():
-        # Return list of state objects, not tuples
-        return list(mock_states.values())
-
     def mock_get_state(entity_id):
         return mock_states.get(entity_id)
 
-    mock_states_obj.async_all = mock_async_all
+    mock_states_obj.async_all = make_mock_async_all(mock_states)
     mock_states_obj.get = mock_get_state
 
     return hass
@@ -133,13 +130,18 @@ class TestOptionalFeaturesDiscovery:
         # Generic power should be last
         assert entities[2] == "sensor.random_sensor"
 
-    async def test_discover_no_degree_minutes(self):
+    async def test_discover_no_degree_minutes(self, monkeypatch):
         """Test when no degree minutes sensor exists."""
         hass = MagicMock(spec=HomeAssistant)
         mock_states_obj = MagicMock()
         hass.states = mock_states_obj
         # Return list of state objects, not tuples
-        mock_states_obj.async_all = lambda: [MagicMock(entity_id="sensor.temperature")]
+        mock_states_obj.async_all = lambda domain_filter=None: [
+            MagicMock(entity_id="sensor.temperature")
+        ]
+        registry = MagicMock()
+        registry.async_get = lambda entity_id: None
+        monkeypatch.setattr("homeassistant.helpers.entity_registry.async_get", lambda h: registry)
 
         config_flow = EffektGuardConfigFlow()
         config_flow.hass = hass
@@ -160,7 +162,7 @@ class TestOptionalFeaturesDiscovery:
         mock_states_obj = MagicMock()
         hass.states = mock_states_obj
         # Return list of state objects, not tuples
-        mock_states_obj.async_all = lambda: [mock_state]
+        mock_states_obj.async_all = lambda domain_filter=None: [mock_state]
 
         config_flow = EffektGuardConfigFlow()
         config_flow.hass = hass

--- a/tests/unit/adapters/test_nibe_discovery.py
+++ b/tests/unit/adapters/test_nibe_discovery.py
@@ -1,0 +1,538 @@
+"""Tests for NIBE adapter entity discovery (issue #18: multi-source support).
+
+Covers the three real-world entity sources:
+- nibe_heatpump (local NibeGW/Modbus): register-suffixed ids, writable coils
+  as NUMBER entities, all entities disabled by default
+- myuplink (cloud): name-based ids without register numbers, writable
+  parameters as NUMBER entities
+- generic modbus YAML: entities WITHOUT unique_id that never enter the entity
+  registry (discovery must scan the state machine)
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from conftest import make_mock_async_all
+from custom_components.effektguard.adapters.nibe_adapter import NibeAdapter
+from custom_components.effektguard.const import (
+    CONF_DHW_TEMP_ENTITY,
+    CONF_NIBE_ENTITY,
+    CONF_OUTDOOR_TEMP_ENTITY,
+)
+
+
+def make_state(entity_id: str, state: str, attributes: dict | None = None) -> MagicMock:
+    """Create a mock HA state object."""
+    mock = MagicMock()
+    mock.entity_id = entity_id
+    mock.state = state
+    mock.attributes = attributes or {}
+    return mock
+
+
+def make_registry_entry(
+    entity_id: str,
+    disabled_by: str | None = None,
+    original_device_class: str | None = None,
+    unit_of_measurement: str | None = None,
+) -> MagicMock:
+    """Create a mock entity registry entry."""
+    entry = MagicMock()
+    entry.entity_id = entity_id
+    entry.domain = entity_id.split(".")[0]
+    entry.disabled_by = disabled_by
+    entry.device_class = None
+    entry.original_device_class = original_device_class
+    entry.unit_of_measurement = unit_of_measurement
+    return entry
+
+
+def make_hass(states: list[MagicMock], registry_entries: list[MagicMock], monkeypatch):
+    """Create a mock hass with a state machine and entity registry."""
+    hass = MagicMock(spec=HomeAssistant)
+    states_by_id = {s.entity_id: s for s in states}
+
+    states_obj = MagicMock()
+    states_obj.async_all = make_mock_async_all(states_by_id)
+    states_obj.get = lambda entity_id: states_by_id.get(entity_id)
+    hass.states = states_obj
+
+    entries_by_id = {e.entity_id: e for e in registry_entries}
+    registry = MagicMock()
+    registry.entities.values.return_value = registry_entries
+    registry.async_get = lambda entity_id: entries_by_id.get(entity_id)
+    monkeypatch.setattr(
+        "custom_components.effektguard.adapters.nibe_adapter.er.async_get",
+        lambda h: registry,
+    )
+    return hass
+
+
+TEMP_ATTRS = {"device_class": "temperature", "unit_of_measurement": "°C"}
+
+
+class TestNibeHeatpumpNaming:
+    """Discovery against official nibe_heatpump entity naming (F1155)."""
+
+    @pytest.fixture
+    def hass(self, monkeypatch):
+        states = [
+            make_state("sensor.bt1_outdoor_temperature_40004", "-3.2", TEMP_ATTRS),
+            make_state("sensor.bt2_supply_temp_s1_40008", "35.8", TEMP_ATTRS),
+            make_state("sensor.eb100_ep14_bt3_return_temp_40012", "31.2", TEMP_ATTRS),
+            make_state("sensor.bt7_hw_top_40013", "48.7", TEMP_ATTRS),
+            make_state("sensor.bt6_hw_load_40014", "44.2", TEMP_ATTRS),
+            make_state("sensor.bt50_room_temp_s1_40033", "21.3", TEMP_ATTRS),
+            make_state("number.degree_minutes_16_bit_43005", "-150.0", {}),
+            make_state("number.heat_offset_s1_47011", "0", {}),
+            make_state("sensor.compressor_frequency_actual_43136", "62.0", {}),
+            make_state("sensor.compressor_state_ep14_43427", "Running", {}),
+            make_state("sensor.prio_43086", "Hot Water", {}),
+        ]
+        return make_hass(states, [], monkeypatch)
+
+    async def test_discovers_all_core_entities(self, hass):
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        cache = adapter.entity_cache
+        assert cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004"
+        assert cache["supply_temp"] == "sensor.bt2_supply_temp_s1_40008"
+        assert cache["return_temp"] == "sensor.eb100_ep14_bt3_return_temp_40012"
+        assert cache["dhw_top_temp"] == "sensor.bt7_hw_top_40013"
+        assert cache["dhw_charging_temp"] == "sensor.bt6_hw_load_40014"
+        assert cache["indoor_temp"] == "sensor.bt50_room_temp_s1_40033"
+        assert cache["degree_minutes"] == "number.degree_minutes_16_bit_43005"
+        assert cache["offset"] == "number.heat_offset_s1_47011"
+        assert cache["compressor_hz"] == "sensor.compressor_frequency_actual_43136"
+        assert cache["compressor_status"] == "sensor.compressor_state_ep14_43427"
+
+    async def test_prio_not_matched_as_phase_current(self, hass):
+        """43086 is the Prio register, NOT a BE current sensor."""
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        for key in ("phase1_current", "phase2_current", "phase3_current"):
+            assert adapter.entity_cache.get(key) != "sensor.prio_43086"
+
+    async def test_mapped_compressor_state_reads_as_active(self, hass):
+        """nibe_heatpump reports mapped strings like 'Running'."""
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        state = await adapter.get_current_state()
+        assert state.is_heating is True
+
+
+class TestMyUplinkNaming:
+    """Discovery against official HA core myuplink entity naming."""
+
+    @pytest.fixture
+    def hass(self, monkeypatch):
+        states = [
+            make_state("sensor.gotham_city_current_outd_temp_bt1", "-3.2", TEMP_ATTRS),
+            make_state("sensor.gotham_city_supply_line_bt2", "35.8", TEMP_ATTRS),
+            make_state("sensor.gotham_city_return_line_bt3", "31.2", TEMP_ATTRS),
+            make_state("sensor.gotham_city_hot_water_top_bt7", "48.7", TEMP_ATTRS),
+            make_state("sensor.gotham_city_hot_water_charging_bt6", "44.2", TEMP_ATTRS),
+            make_state("sensor.gotham_city_room_temperature_bt50", "21.3", TEMP_ATTRS),
+            make_state("number.gotham_city_degree_minutes", "-150.0", {}),
+            make_state("number.gotham_city_heating_offset_climate_system_1", "0", {}),
+            make_state("sensor.gotham_city_status_compressor", "Running", {}),
+        ]
+        return make_hass(states, [], monkeypatch)
+
+    async def test_discovers_all_core_entities(self, hass):
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        cache = adapter.entity_cache
+        assert cache["outdoor_temp"] == "sensor.gotham_city_current_outd_temp_bt1"
+        assert cache["supply_temp"] == "sensor.gotham_city_supply_line_bt2"
+        assert cache["return_temp"] == "sensor.gotham_city_return_line_bt3"
+        assert cache["dhw_top_temp"] == "sensor.gotham_city_hot_water_top_bt7"
+        assert cache["dhw_charging_temp"] == "sensor.gotham_city_hot_water_charging_bt6"
+        assert cache["indoor_temp"] == "sensor.gotham_city_room_temperature_bt50"
+        assert cache["degree_minutes"] == "number.gotham_city_degree_minutes"
+        assert cache["offset"] == "number.gotham_city_heating_offset_climate_system_1"
+        assert cache["compressor_status"] == "sensor.gotham_city_status_compressor"
+
+    async def test_bt7_not_stolen_by_hot_water_status(self, hass):
+        """hot_water_top_bt7 must claim dhw_top_temp, not hot_water_status."""
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert (
+            adapter.entity_cache.get("hot_water_status") != "sensor.gotham_city_hot_water_top_bt7"
+        )
+
+
+class TestMyUplinkF750LegacyNaming:
+    """MyUplink remains a first-class source: the maintainer's own F750
+    system naming (f750_cu_3x400v_*) must keep resolving after the Modbus
+    additions. Guards against any regression that 'removes MyUplink'."""
+
+    @pytest.fixture
+    def hass(self, monkeypatch):
+        states = [
+            make_state("sensor.f750_cu_3x400v_outdoor_temperature_bt1", "-3.2", TEMP_ATTRS),
+            make_state("sensor.f750_cu_3x400v_room_temperature_bt50", "21.3", TEMP_ATTRS),
+            make_state("sensor.f750_cu_3x400v_heating_medium_supply_bt63", "35.8", TEMP_ATTRS),
+            make_state("sensor.f750_cu_3x400v_return_line_bt3", "31.2", TEMP_ATTRS),
+            make_state("sensor.f750_cu_3x400v_hot_water_top_bt7", "48.7", TEMP_ATTRS),
+            make_state("sensor.f750_cu_3x400v_hot_water_charging_bt6", "44.2", TEMP_ATTRS),
+            make_state("sensor.f750_cu_3x400v_degree_minutes", "-150", {}),
+            make_state("number.f750_cu_3x400v_offset", "0", {}),
+            make_state("sensor.f750_cu_3x400v_current_be1", "3.1", {}),
+            make_state("sensor.f750_cu_3x400v_current_be2", "2.9", {}),
+            make_state("sensor.f750_cu_3x400v_current_be3", "3.0", {}),
+            make_state("sensor.f750_cu_3x400v_compressor_status", "on", {}),
+            make_state("sensor.f750_cu_3x400v_current_compressor_frequency", "62", {}),
+            make_state("switch.f750_cu_3x400v_increased_ventilation", "off", {}),
+        ]
+        registry_entries = []
+        for s in states:
+            entry = make_registry_entry(s.entity_id)
+            entry.platform = "myuplink"
+            registry_entries.append(entry)
+        return make_hass(states, registry_entries, monkeypatch)
+
+    async def test_all_f750_myuplink_entities_discovered(self, hass):
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        cache = adapter.entity_cache
+        assert cache["outdoor_temp"] == "sensor.f750_cu_3x400v_outdoor_temperature_bt1"
+        assert cache["indoor_temp"] == "sensor.f750_cu_3x400v_room_temperature_bt50"
+        assert cache["supply_temp"] == "sensor.f750_cu_3x400v_heating_medium_supply_bt63"
+        assert cache["return_temp"] == "sensor.f750_cu_3x400v_return_line_bt3"
+        assert cache["dhw_top_temp"] == "sensor.f750_cu_3x400v_hot_water_top_bt7"
+        assert cache["dhw_charging_temp"] == "sensor.f750_cu_3x400v_hot_water_charging_bt6"
+        assert cache["degree_minutes"] == "sensor.f750_cu_3x400v_degree_minutes"
+        assert cache["offset"] == "number.f750_cu_3x400v_offset"
+        assert cache["phase1_current"] == "sensor.f750_cu_3x400v_current_be1"
+        assert cache["phase2_current"] == "sensor.f750_cu_3x400v_current_be2"
+        assert cache["phase3_current"] == "sensor.f750_cu_3x400v_current_be3"
+        assert cache["compressor_status"] == "sensor.f750_cu_3x400v_compressor_status"
+        assert cache["compressor_hz"] == ("sensor.f750_cu_3x400v_current_compressor_frequency")
+        assert cache["increased_ventilation"] == ("switch.f750_cu_3x400v_increased_ventilation")
+
+    async def test_f750_state_reads_correctly(self, hass):
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        state = await adapter.get_current_state()
+        assert state.outdoor_temp == -3.2
+        assert state.supply_temp == 35.8
+        assert state.degree_minutes == -150
+        assert state.is_heating is True
+        assert state.dhw_top_temp == 48.7
+
+
+class TestGenericModbusStatesOnly:
+    """Generic modbus YAML entities have no unique_id and never enter the
+    entity registry - discovery must find them in the state machine."""
+
+    @pytest.fixture
+    def hass(self, monkeypatch):
+        # Reproduces the live devbox setup that reproduced issue #18
+        states = [
+            make_state("sensor.bt1_outdoor_temperature_40004", "-3.2", TEMP_ATTRS),
+            make_state("sensor.bt7_hw_top_40013", "48.7", TEMP_ATTRS),
+            make_state("sensor.degree_minutes_43005", "-150.0", {}),
+            make_state("sensor.heating_offset_s1_47011", "0", {}),
+            make_state("number.heating_offset_climate_system_1_47011", "0.0", {}),
+        ]
+        return make_hass(states, [], monkeypatch)
+
+    async def test_states_without_registry_are_discovered(self, hass):
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        cache = adapter.entity_cache
+        assert cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004"
+        assert cache["dhw_top_temp"] == "sensor.bt7_hw_top_40013"
+        assert cache["degree_minutes"] == "sensor.degree_minutes_43005"
+
+    async def test_offset_never_binds_to_readonly_sensor(self, hass):
+        """The write path calls number.set_value - offset must be a number."""
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert adapter.entity_cache["offset"] == "number.heating_offset_climate_system_1_47011"
+
+    async def test_offset_unset_when_only_sensor_exists(self, monkeypatch):
+        hass = make_hass([make_state("sensor.heating_offset_s1_47011", "0", {})], [], monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert "offset" not in adapter.entity_cache
+
+
+class TestManualOverrides:
+    """Manual config-flow overrides beat pattern discovery."""
+
+    async def test_overrides_win_over_discovery(self, monkeypatch):
+        states = [
+            make_state("sensor.bt1_outdoor_temperature_40004", "-3.2", TEMP_ATTRS),
+            make_state("sensor.my_own_outdoor", "-5.0", TEMP_ATTRS),
+            make_state("sensor.my_own_dhw_top", "47.0", TEMP_ATTRS),
+            make_state("number.heat_offset_s1_47011", "0", {}),
+            make_state("number.my_offset_control", "0", {}),
+        ]
+        hass = make_hass(states, [], monkeypatch)
+        adapter = NibeAdapter(
+            hass,
+            {
+                CONF_NIBE_ENTITY: "number.my_offset_control",
+                CONF_OUTDOOR_TEMP_ENTITY: "sensor.my_own_outdoor",
+                CONF_DHW_TEMP_ENTITY: "sensor.my_own_dhw_top",
+            },
+        )
+        await adapter.discover_entities()
+
+        cache = adapter.entity_cache
+        assert cache["offset"] == "number.my_offset_control"
+        assert cache["outdoor_temp"] == "sensor.my_own_outdoor"
+        assert cache["dhw_top_temp"] == "sensor.my_own_dhw_top"
+
+
+class TestRegistryEdgeCases:
+    """Disabled and stale registry entries (nibe_heatpump disables all coil
+    entities by default; re-added entries leave stale ids behind)."""
+
+    async def test_disabled_registry_entries_skipped(self, monkeypatch):
+        registry_entries = [
+            make_registry_entry(
+                "sensor.bt7_hw_top_40013",
+                disabled_by="integration",
+                original_device_class="temperature",
+            ),
+        ]
+        hass = make_hass([], registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert "dhw_top_temp" not in adapter.entity_cache
+
+    async def test_live_entity_beats_stale_registry_entry(self, monkeypatch):
+        """Issue #18: sensor.bt1_..._40004_2 is live; the base id is a stale
+        registry leftover without a state. The live entity must win."""
+        states = [
+            make_state("sensor.bt1_outdoor_temperature_40004_2", "-3.2", TEMP_ATTRS),
+        ]
+        registry_entries = [
+            make_registry_entry(
+                "sensor.bt1_outdoor_temperature_40004",
+                original_device_class="temperature",
+            ),
+        ]
+        hass = make_hass(states, registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert adapter.entity_cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004_2"
+
+    async def test_registry_only_entry_used_when_no_live_entity(self, monkeypatch):
+        """Enabled-but-not-yet-loaded entities are still cached (startup)."""
+        registry_entries = [
+            make_registry_entry(
+                "sensor.bt1_outdoor_temperature_40004",
+                original_device_class="temperature",
+            ),
+        ]
+        hass = make_hass([], registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert adapter.entity_cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004"
+
+    async def test_live_entity_displaces_registry_entry_on_later_pass(self, monkeypatch):
+        """Ranks persist across passes: an entity that becomes live AFTER the
+        first discovery pass (source integration finished starting) must
+        replace the registry-only entry cached during startup."""
+        registry_entries = [
+            make_registry_entry(
+                "sensor.bt1_outdoor_temperature_40004",
+                original_device_class="temperature",
+            ),
+        ]
+        hass = make_hass([], registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+        assert adapter.entity_cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004"
+
+        # The integration finishes loading: a different live BT1 appears
+        hass2 = make_hass(
+            [make_state("sensor.bt1_outdoor_temperature_40004_2", "-3.2", TEMP_ATTRS)],
+            registry_entries,
+            monkeypatch,
+        )
+        adapter.hass = hass2
+        await adapter.discover_entities()
+
+        assert adapter.entity_cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004_2"
+
+    async def test_own_entities_excluded_by_platform(self, monkeypatch):
+        """EffektGuard's own entities must never be discovered as sources."""
+        states = [
+            make_state("sensor.effektguard_dhw_status", "Scheduled", {}),
+        ]
+        registry_entries = [
+            make_registry_entry("sensor.effektguard_dhw_status"),
+        ]
+        registry_entries[0].platform = "effektguard"
+        hass = make_hass(states, registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert "hot_water_status" not in adapter.entity_cache
+
+
+class TestStartupRaces:
+    """Source integrations create entities after EffektGuard's first pass."""
+
+    async def test_core_keys_from_registry_trigger_rediscovery(self, monkeypatch):
+        """A core key backed only by a stale registry entry must not stop
+        re-discovery: the live entity appearing later has to take over
+        (issue #18: re-added nibe_heatpump leaves stale enabled ids)."""
+        registry_entries = [
+            make_registry_entry(
+                "sensor.bt1_outdoor_temperature_40004",
+                original_device_class="temperature",
+            ),
+        ]
+        hass = make_hass([], registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        # First cycle: only the stale registry entry exists
+        await adapter.get_current_state()
+        assert adapter.entity_cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004"
+
+        # Live entities appear; the next cycle must re-discover and displace
+        hass2 = make_hass(
+            [
+                make_state("sensor.bt1_outdoor_temperature_40004_2", "-3.2", TEMP_ATTRS),
+                make_state("sensor.bt50_room_temp_s1_40033", "21.3", TEMP_ATTRS),
+                make_state("sensor.bt2_supply_temp_s1_40008", "35.8", TEMP_ATTRS),
+            ],
+            registry_entries,
+            monkeypatch,
+        )
+        adapter.hass = hass2
+        state = await adapter.get_current_state()
+
+        assert adapter.entity_cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004_2"
+        assert state.outdoor_temp == -3.2
+
+    async def test_switch_found_via_registry_before_platform_loads(self, monkeypatch):
+        """Ventilation switch registered but without a state yet is found."""
+        registry_entries = [
+            make_registry_entry("switch.f750_increased_ventilation"),
+        ]
+        registry_entries[0].platform = "myuplink"
+        hass = make_hass([], registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert adapter.entity_cache["increased_ventilation"] == (
+            "switch.f750_increased_ventilation"
+        )
+
+    async def test_bedroom_temp_not_matched_as_indoor(self, monkeypatch):
+        """Unrelated *room_temp* sensors must not claim indoor_temp."""
+        states = [
+            make_state("sensor.bedroom_temp", "19.5", TEMP_ATTRS),
+            make_state("sensor.storeroom_temp_2", "15.0", TEMP_ATTRS),
+        ]
+        hass = make_hass(states, [], monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert "indoor_temp" not in adapter.entity_cache
+
+    async def test_offset_override_available_before_discovery(self, monkeypatch):
+        """The coordinator reads entity_cache['offset'] before the first
+        discovery pass - manual overrides must be seeded at construction."""
+        hass = make_hass([], [], monkeypatch)
+        adapter = NibeAdapter(hass, {CONF_NIBE_ENTITY: "number.my_offset"})
+
+        assert adapter.entity_cache.get("offset") == "number.my_offset"
+
+    async def test_registered_entity_beats_unregistered_lookalike(self, monkeypatch):
+        """A template/YAML lookalike without a registry entry must not steal
+        a key from a real integration entity, regardless of iteration order."""
+        lookalike = make_state("sensor.outdoor_temp_smoothed", "-2.9", TEMP_ATTRS)
+        real = make_state("sensor.bt1_outdoor_temperature_40004", "-3.2", TEMP_ATTRS)
+        registry_entries = [
+            make_registry_entry(
+                "sensor.bt1_outdoor_temperature_40004",
+                original_device_class="temperature",
+            ),
+        ]
+        registry_entries[0].platform = "nibe_heatpump"
+        # Lookalike iterates FIRST
+        hass = make_hass([lookalike, real], registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert adapter.entity_cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004"
+
+    async def test_registry_binding_upgrades_to_live_and_resists_theft(self, monkeypatch):
+        """A key bound from the registry pass must upgrade to live rank when
+        its state appears, so a later lookalike cannot displace it."""
+        registry_entries = [
+            make_registry_entry(
+                "sensor.bt1_outdoor_temperature_40004",
+                original_device_class="temperature",
+            ),
+        ]
+        registry_entries[0].platform = "nibe_heatpump"
+        hass = make_hass([], registry_entries, monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        # BT1 comes alive; an unregistered lookalike iterates before it
+        states = [
+            make_state("sensor.outdoor_temp_smoothed", "-2.9", TEMP_ATTRS),
+            make_state("sensor.bt1_outdoor_temperature_40004", "-3.2", TEMP_ATTRS),
+        ]
+        hass2 = make_hass(states, registry_entries, monkeypatch)
+        adapter.hass = hass2
+        await adapter.discover_entities()
+
+        assert adapter.entity_cache["outdoor_temp"] == "sensor.bt1_outdoor_temperature_40004"
+
+
+class TestStatusParsing:
+    """Status reads across sources: on/off, mapped strings, numeric enums."""
+
+    async def test_numeric_compressor_state_falls_back_to_frequency(self, monkeypatch):
+        """Raw Modbus 43427 is a numeric enum the bool parser cannot read;
+        is_heating must derive from compressor frequency instead."""
+        states = [
+            make_state("sensor.compressor_status_ep14_43427", "60", {}),
+            make_state("sensor.compressor_frequency_43136", "62.0", {}),
+        ]
+        hass = make_hass(states, [], monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        state = await adapter.get_current_state()
+        assert state.is_heating is True
+        assert state.compressor_hz == 62
+
+    async def test_zero_frequency_is_not_heating_and_not_none(self, monkeypatch):
+        states = [
+            make_state("sensor.compressor_frequency_43136", "0.0", {}),
+        ]
+        hass = make_hass(states, [], monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        state = await adapter.get_current_state()
+        assert state.is_heating is False
+        # 0 Hz is a valid reading, not "unknown"
+        assert state.compressor_hz == 0

--- a/tests/unit/adapters/test_nibe_discovery.py
+++ b/tests/unit/adapters/test_nibe_discovery.py
@@ -109,6 +109,7 @@ class TestNibeHeatpumpNaming:
         assert cache["offset"] == "number.heat_offset_s1_47011"
         assert cache["compressor_hz"] == "sensor.compressor_frequency_actual_43136"
         assert cache["compressor_status"] == "sensor.compressor_state_ep14_43427"
+        assert cache["prio"] == "sensor.prio_43086"
 
     async def test_prio_not_matched_as_phase_current(self, hass):
         """43086 is the Prio register, NOT a BE current sensor."""
@@ -118,13 +119,26 @@ class TestNibeHeatpumpNaming:
         for key in ("phase1_current", "phase2_current", "phase3_current"):
             assert adapter.entity_cache.get(key) != "sensor.prio_43086"
 
-    async def test_mapped_compressor_state_reads_as_active(self, hass):
-        """nibe_heatpump reports mapped strings like 'Running'."""
+    async def test_dhw_priority_run_is_not_heating(self, hass):
+        """The fixture's prio is 'Hot Water' while the compressor reports
+        'Running': that is a DHW production run, NOT space heating."""
         adapter = NibeAdapter(hass, {})
         await adapter.discover_entities()
 
         state = await adapter.get_current_state()
+        assert state.is_hot_water is True
+        assert state.is_heating is False
+
+    async def test_heating_priority_run_is_heating(self, hass, monkeypatch):
+        """With prio 'Heat' and compressor 'Running', the run counts as
+        space heating and not as hot water."""
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+        hass.states.get("sensor.prio_43086").state = "Heat"
+
+        state = await adapter.get_current_state()
         assert state.is_heating is True
+        assert state.is_hot_water is False
 
 
 class TestMyUplinkNaming:
@@ -523,6 +537,53 @@ class TestStatusParsing:
         state = await adapter.get_current_state()
         assert state.is_heating is True
         assert state.compressor_hz == 62
+
+    async def test_numeric_dhw_priority_is_not_heating(self, monkeypatch):
+        """Raw Modbus priority 20 (Hot Water) with the compressor spinning:
+        DHW production, not space heating - even though the numeric status
+        enum is unreadable and the frequency fallback would fire."""
+        states = [
+            make_state("sensor.prio_43086", "20", {}),
+            make_state("sensor.compressor_status_ep14_43427", "60", {}),
+            make_state("sensor.compressor_frequency_43136", "62.0", {}),
+        ]
+        hass = make_hass(states, [], monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        state = await adapter.get_current_state()
+        assert state.is_hot_water is True
+        assert state.is_heating is False
+
+    async def test_numeric_heating_priority_is_heating(self, monkeypatch):
+        """Raw Modbus priority 30 (Heat) with the compressor spinning."""
+        states = [
+            make_state("sensor.prio_43086", "30", {}),
+            make_state("sensor.compressor_frequency_43136", "62.0", {}),
+        ]
+        hass = make_hass(states, [], monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        state = await adapter.get_current_state()
+        assert state.is_heating is True
+        assert state.is_hot_water is False
+
+    async def test_unknown_priority_leaves_status_reads_untouched(self, monkeypatch):
+        """MyUplink priority enums are not fully documented (raw 31 observed):
+        unknown values must not override the pattern-based status reads."""
+        states = [
+            make_state("sensor.gotham_city_priority", "31", {}),
+            make_state("sensor.gotham_city_status_compressor", "Running", {}),
+        ]
+        hass = make_hass(states, [], monkeypatch)
+        adapter = NibeAdapter(hass, {})
+        await adapter.discover_entities()
+
+        assert adapter.entity_cache["prio"] == "sensor.gotham_city_priority"
+        state = await adapter.get_current_state()
+        assert state.is_heating is True  # from compressor status, not prio
+        assert state.is_hot_water is False
 
     async def test_zero_frequency_is_not_heating_and_not_none(self, monkeypatch):
         states = [

--- a/tests/unit/adapters/test_nibe_write_path.py
+++ b/tests/unit/adapters/test_nibe_write_path.py
@@ -1,0 +1,126 @@
+"""Tests for the NIBE offset write path (set_curve_offset).
+
+Covers the doc-driven hardening (blocking service call, entity min/max clamp,
+malformed-attribute robustness, unknown-value markers) added while making the
+integration multi-source. The write path must never raise into the coordinator
+and must not record phantom success when the service call fails.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.effektguard.adapters.nibe_adapter import NibeAdapter
+from custom_components.effektguard.const import (
+    CONF_NIBE_ENTITY,
+    NIBE_UNKNOWN_VALUE_MARKERS,
+)
+
+
+def make_adapter(offset_state="0", offset_attrs=None, call_side_effect=None):
+    """Build an adapter whose offset entity is number.offset with given attrs."""
+    hass = MagicMock(spec=HomeAssistant)
+    state = MagicMock()
+    state.state = offset_state
+    state.attributes = offset_attrs if offset_attrs is not None else {}
+    states = MagicMock()
+    states.get = lambda entity_id: state
+    hass.states = states
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock(side_effect=call_side_effect)
+
+    adapter = NibeAdapter(hass, {CONF_NIBE_ENTITY: "number.offset"})
+    return adapter, hass
+
+
+class TestOffsetWriteBlocking:
+    """The write must block and surface handler failures, not fire-and-forget."""
+
+    async def test_successful_write_is_blocking(self):
+        adapter, hass = make_adapter()
+        # Big offset so the accumulator crosses the +-1 threshold from 0
+        result = await adapter.set_curve_offset(3.0)
+
+        assert result is True
+        call = hass.services.async_call.call_args
+        assert call.args[:2] == ("number", "set_value")
+        assert call.kwargs["blocking"] is True
+        assert call.kwargs.get("entity_id") or call.args[2]["entity_id"] == "number.offset"
+
+    async def test_handler_failure_does_not_record_success(self):
+        """A ServiceValidationError (HomeAssistantError subclass) must be
+        caught and must NOT advance _last_nibe_offset."""
+        adapter, hass = make_adapter(call_side_effect=HomeAssistantError("value out of range"))
+        result = await adapter.set_curve_offset(3.0)
+
+        assert result is False
+        # bookkeeping not advanced to the failed value
+        assert adapter._last_nibe_offset == 0
+        assert adapter._last_write is None
+
+    async def test_handler_failure_never_raises(self):
+        """The coordinator relies on set_curve_offset never raising."""
+        adapter, hass = make_adapter(call_side_effect=TypeError("boom"))
+        # Must not raise
+        result = await adapter.set_curve_offset(3.0)
+        assert result is False
+
+
+class TestOffsetClamp:
+    """Respect the target number's own min/max."""
+
+    async def test_clamps_to_entity_max(self):
+        adapter, hass = make_adapter(offset_attrs={"min": -10.0, "max": 5.0})
+        await adapter.set_curve_offset(8.0)
+
+        written = hass.services.async_call.call_args.args[2]["value"]
+        assert written == 5  # clamped to entity max, not MAX_OFFSET (10)
+
+    async def test_clamps_to_entity_min_for_negative(self):
+        adapter, hass = make_adapter(offset_state="0", offset_attrs={"min": -3.0, "max": 3.0})
+        await adapter.set_curve_offset(-8.0)
+
+        written = hass.services.async_call.call_args.args[2]["value"]
+        assert written == -3
+
+    async def test_default_template_number_range_still_allows_configured(self):
+        """A template number left at 0-100 clamps negatives to 0 and warns
+        rather than silently failing in a background task."""
+        adapter, hass = make_adapter(offset_attrs={"min": 0.0, "max": 100.0})
+        # -2 requested; clamps to 0, equals current -> no write, no crash
+        result = await adapter.set_curve_offset(-2.0)
+        assert result is False
+
+    async def test_malformed_minmax_does_not_crash(self):
+        """Non-numeric min/max attributes must be ignored, not raise."""
+        adapter, hass = make_adapter(offset_attrs={"min": "n/a", "max": None})
+        result = await adapter.set_curve_offset(3.0)
+
+        # Falls back to MIN_OFFSET/MAX_OFFSET clamp, write still succeeds
+        assert result is True
+        written = hass.services.async_call.call_args.args[2]["value"]
+        assert written == 3
+
+
+class TestUnknownValueMarker:
+    """-32768 / -3276.8 are 'no reading' markers, not real values."""
+
+    async def test_marker_read_as_default(self):
+        hass = MagicMock(spec=HomeAssistant)
+        state = MagicMock()
+        state.state = "-32768"
+        state.attributes = {}
+        hass.states = MagicMock()
+        hass.states.get = lambda entity_id: state
+        adapter = NibeAdapter(hass, {})
+
+        value = await adapter._read_entity_float("sensor.x", default=99.0)
+        assert value == 99.0
+
+    def test_both_markers_defined(self):
+        assert -32768.0 in NIBE_UNKNOWN_VALUE_MARKERS
+        assert -3276.8 in NIBE_UNKNOWN_VALUE_MARKERS

--- a/tests/unit/coordinator/test_manual_override_bypass.py
+++ b/tests/unit/coordinator/test_manual_override_bypass.py
@@ -1,0 +1,139 @@
+"""Manual force_offset commands must bypass the volatile-reversal blocker.
+
+Live-reproduced regression risk: after a +4°C offset, a user-commanded
+effektguard.force_offset with offset 0 was accepted by the service and the
+decision engine, but the coordinator's volatility blocker deferred it as a
+volatile reversal and kept the previous +4°C for 45 minutes. User commands
+are authoritative and must apply immediately; the blocker still applies to
+automatic decisions.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.effektguard.coordinator import EffektGuardCoordinator
+from custom_components.effektguard.optimization.decision_engine import OptimizationDecision
+
+
+def _make_minimal_hass() -> MagicMock:
+    hass = MagicMock()
+    hass.data = {}
+    hass.config = MagicMock()
+    hass.config.latitude = 59.3
+    hass.config.config_dir = "/tmp/test"
+    hass.loop = MagicMock()
+    hass.loop.call_soon_threadsafe = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda func, *args: func(*args))
+    hass.async_create_task = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=None)
+    hass.bus = MagicMock()
+    hass.bus.async_listen = MagicMock(return_value=lambda: None)
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    return hass
+
+
+def _make_coordinator(decision: OptimizationDecision) -> EffektGuardCoordinator:
+    """Coordinator past the startup grace period, one update from `decision`."""
+    hass = _make_minimal_hass()
+
+    nibe_data = SimpleNamespace(
+        indoor_temp=21.0,
+        outdoor_temp=0.0,
+        flow_temp=32.0,
+        degree_minutes=-150.0,
+        current_offset=4.0,
+        compressor_hz=40,
+        timestamp=datetime.now(timezone.utc),
+        power_kw=2.0,
+        is_heating=True,
+        is_hot_water=False,
+        dhw_top_temp=None,
+        dhw_amount_minutes=None,
+        phase1_current=None,
+        phase2_current=None,
+        phase3_current=None,
+    )
+    nibe = MagicMock()
+    nibe.get_current_state = AsyncMock(return_value=nibe_data)
+    nibe.set_curve_offset = AsyncMock(return_value=True)
+    nibe.power_sensor_entity = None
+    nibe._power_sensor_entity = None
+
+    engine = MagicMock()
+    engine.calculate_decision = MagicMock(return_value=decision)
+    engine.price = MagicMock()
+    engine.price.get_current_classification = MagicMock(return_value="normal")
+
+    effect = MagicMock()
+    effect.async_save = AsyncMock()
+
+    coordinator = EffektGuardCoordinator(
+        hass=hass,
+        nibe_adapter=nibe,
+        gespot_adapter=MagicMock(get_prices=AsyncMock(return_value=None)),
+        weather_adapter=MagicMock(get_forecast=AsyncMock(return_value=None)),
+        decision_engine=engine,
+        effect_manager=effect,
+        entry=MagicMock(data={"enable_optimization": True}, options={}),
+    )
+
+    # Defeat the startup grace period: control actions are live
+    coordinator._startup_grace_timeout = dt_util.now() - timedelta(seconds=5)
+    coordinator._startup_update_count = coordinator._startup_grace_updates
+
+    # Avoid unrelated side-effects
+    coordinator._update_peak_tracking = AsyncMock()
+    coordinator._record_learning_observations = AsyncMock()
+    coordinator._schedule_aligned_refresh = MagicMock()
+
+    # History exactly as in the live repro: offset went 0 -> +4 just now,
+    # so a drop back to 0 is a large opposite-direction change within the
+    # volatility window
+    coordinator._offset_volatility_tracker.record_change(0.0, "baseline")
+    coordinator._offset_volatility_tracker.record_change(4.0, "raise")
+
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_manual_reduction_applies_immediately_after_raise():
+    """force_offset(0) right after +4°C must be applied, not deferred."""
+    manual = OptimizationDecision(
+        offset=0.0,
+        reasoning="Manual override active: 0.0°C",
+        is_manual_override=True,
+    )
+    coordinator = _make_coordinator(manual)
+
+    await coordinator._async_update_data()
+
+    assert coordinator.current_offset == 0.0
+    coordinator.nibe.set_curve_offset.assert_awaited_with(0.0)
+    # The tracker adopted the manual value as the new baseline
+    assert coordinator._offset_volatility_tracker.last_offset == 0.0
+
+
+@pytest.mark.asyncio
+async def test_automatic_reversal_still_blocked():
+    """The volatility blocker must keep protecting against AUTOMATIC
+    rapid reversals - only user commands bypass it."""
+    automatic = OptimizationDecision(
+        offset=0.0,
+        reasoning="price reduction",
+        is_manual_override=False,
+    )
+    coordinator = _make_coordinator(automatic)
+
+    await coordinator._async_update_data()
+
+    # Blocked: previous +4°C retained
+    assert coordinator.current_offset == 4.0

--- a/tests/unit/models/test_heat_pump_models.py
+++ b/tests/unit/models/test_heat_pump_models.py
@@ -58,17 +58,18 @@ class TestModelRegistry:
 
         assert "nibe_f730" in nibe_models
         assert "nibe_f750" in nibe_models
+        assert "nibe_f1155" in nibe_models
         assert "nibe_f2040" in nibe_models
         assert "nibe_s1155" in nibe_models
         # S1255 removed - doesn't exist
-        assert len(nibe_models) == 4
+        assert len(nibe_models) == 5
 
     def test_get_models_grouped_by_manufacturer(self):
         """Test getting models grouped by manufacturer."""
         grouped = HeatPumpModelRegistry.get_models_grouped_by_manufacturer()
 
         assert "NIBE" in grouped
-        assert len(grouped["NIBE"]) == 4  # S1255 removed
+        assert len(grouped["NIBE"]) == 5  # F1155 added for issue #18
 
         # Check structure
         f750 = next(m for m in grouped["NIBE"] if m["id"] == "nibe_f750")


### PR DESCRIPTION
## Summary

Closes #18. A NIBE F1155 owner on local **Modbus** (via the official `nibe_heatpump` integration) could not configure EffektGuard: discovery only recognised MyUplink entity naming, and the config flow rejected the `number` entities that both `nibe_heatpump` and MyUplink expose for writable registers (degree minutes, curve offset).

This adds **Modbus** and **`nibe_heatpump`** as first-class data sources **without removing MyUplink** — MyUplink remains fully supported and is covered by a dedicated regression test using real `f750_cu_3x400v_*` naming.

Scoped to the source-support change only; the simulation harness, investigation record, and governance rule are in a separate dev-tooling PR.

## What changed

- **Adapter discovery rewritten** — scans the state machine *and* entity registry (generic Modbus YAML sensors have no `unique_id` and never enter the registry); manual overrides are authoritative; live entities beat stale/disabled registry entries; one key per entity. Source-neutral patterns cover MyUplink, `nibe_heatpump`, and generic Modbus, with corrected NIBE register facts (BE currents 40079/40081/40079→40083 family; 43086 is Prio, not a phase current; map source: yozik04/nibe `nibe/data/f1155_f1255.json`).
- **Priority-aware status** *(external review, High)* — new `prio` discovery key (register 43086) with value mapping for mapped strings and raw numerics: a compressor run with **hot-water priority never counts as space heating**; unknown MyUplink enums conservatively leave the pattern-based reads untouched.
- **Manual offsets are authoritative** *(external review; pre-existing, live-reproduced)* — `effektguard.force_offset` decisions now bypass the volatile-reversal blocker and re-baseline the tracker; automatic reversals remain blocked. Previously a manual reduction could be silently deferred 45 minutes.
- **Config flow** — degree-minutes/override selectors accept `sensor`/`number`/`input_number`; six manual sensor-override fields (setup + Reconfigure); heat-pump model and offset entity changeable via Reconfigure; all steps translated (en/sv/da/no/fi).
- **New `NibeF1155` GSHP profile**; single model registry (removed the duplicate dict that silently fell back to F750).
- **Write path hardened** — blocking service calls surface handler failures instead of recording phantom success; the target number's own min/max is respected; `-32768` unknown-value markers ignored; tracked offset re-syncs from the entity on drift.
- Source-neutral user messages; README **Local Modbus** setup recipe; `after_dependencies` += `modbus`, `nibe_heatpump`; `hacs.json` HA version aligned to the README.

## Testing

- **1146 tests pass**, Black clean. **+40 new tests** across `tests/unit/adapters/test_nibe_discovery.py` (nibe_heatpump / MyUplink / generic-Modbus naming, manual overrides, disabled/stale registry entries, startup races, rank displacement, priority classification incl. raw numeric and unknown-enum cases), `test_nibe_write_path.py` (blocking write, min/max clamp, malformed-attribute robustness, unknown-value markers), and `tests/unit/coordinator/test_manual_override_bypass.py` (manual applies immediately; automatic reversal still blocked).
- Verified **end-to-end against a real Modbus TCP stack** in a live Home Assistant: discovery in a single pass on real values, and the offset write landing at register 47011 (`0°C → 4°C`).

## Not fully exercised here

The test suite is mock-based and the live verification covered the **local-Modbus** path only. Real **MyUplink cloud** (needs OAuth) and the actual **`nibe_heatpump`** integration were not driven live — recommended follow-up before relying on those paths in production.